### PR TITLE
v1.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## v1.2.5 - Bug Fixes and QoL Improvements
+
+### Quality of Life Improvements
+
+- Adjusted the styling around the calendar configuration tabs. The tab titles shouldn't break into multiple lines unless the config window is shrunk and if they do break into multiple lines it should look cleaner.
+- Adjusted the starting height of the calendar to have more space for the events list.
+- Updated adding/editing a note so that the text editor does not need to be saved before saving the note. When saving the note any content entered will be saved.
+- Updated the weekday headings so that the first 2 characters of the weekday name are shown. This will help distinguish between days of the week that start with the same character.
+
+### Bug Fixes
+
+- Fixed a bug where in some instances importing data from Calendar/Weather into Simple Calendar would incorrectly save numerical data as strings causing Simple Calendar to not open.
+
 ## v1.2.0 - Time, Other Modules, Seasons, Moons and Notes
 
 This update was a long time coming so apologies for making you wait for it. This update with most of the currently requested changes to Simple Calendar

--- a/docs/Notes.md
+++ b/docs/Notes.md
@@ -1,4 +1,4 @@
-#Notes
+# Notes
 
 All information around viewing, adding, editing and removing notes.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "foundryvtt-simple-calendar",
   "description": "A simple calendar module for keeping track of game days and events.",
-  "version": "1.2.0",
+  "version": "1.2.5",
   "author": "Dean Vigoren (vigorator)",
   "keywords": [
     "foundryvtt",

--- a/src/classes/importer.test.ts
+++ b/src/classes/importer.test.ts
@@ -138,7 +138,15 @@ describe('Importer Class Tests', () => {
                     leapLength: 1,
                     isNumbered: false,
                     abbrev: ''
+                },
+                {
+                    name: 'Month 4',
+                    length: "asd",
+                    leapLength: "asd",
+                    isNumbered: true,
+                    abbrev: ''
                 }
+
             ],
             daysOfTheWeek: ["S","M","T"],
             year: 12,
@@ -192,7 +200,7 @@ describe('Importer Class Tests', () => {
         expect(y.weekdays[0].name).toBe('S');
         expect(y.weekdays[1].name).toBe('M');
         expect(y.weekdays[2].name).toBe('T');
-        expect(y.months.length).toBe(3);
+        expect(y.months.length).toBe(4);
         expect(y.months[0].name).toBe('Month 1');
         expect(y.months[0].numberOfDays).toBe(10);
         expect(y.months[0].numberOfLeapYearDays).toBe(10);
@@ -205,6 +213,10 @@ describe('Importer Class Tests', () => {
         expect(y.months[2].numberOfDays).toBe(1);
         expect(y.months[2].numberOfLeapYearDays).toBe(1);
         expect(y.months[2].intercalary).toBe(true);
+        expect(y.months[3].name).toBe('Month 4');
+        expect(y.months[3].numberOfDays).toBe(1);
+        expect(y.months[3].numberOfLeapYearDays).toBe(1);
+        expect(y.months[3].intercalary).toBe(false);
         expect(y.leapYearRule.rule).toBe(LeapYearRules.None);
     });
 

--- a/src/classes/importer.ts
+++ b/src/classes/importer.ts
@@ -142,7 +142,16 @@ export default class Importer{
         let mCount = 1;
         let mICount = 1;
         for(let i = 0; i < currentSettings.months.length; i++){
-            const nMonth = new Month(currentSettings.months[i].name, i+1, currentSettings.months[i].length, currentSettings.months[i].leapLength)
+            let numDays = parseInt(currentSettings.months[i].length.toString());
+            let numLeapDays = parseInt(currentSettings.months[i].leapLength.toString());
+            if(isNaN(numDays)){
+                numDays = 1;
+            }
+            if(isNaN(numLeapDays)){
+                numLeapDays = 1;
+            }
+
+            const nMonth = new Month(currentSettings.months[i].name, i+1, numDays, numLeapDays)
             if(!currentSettings.months[i].isNumbered){
                 nMonth.numericRepresentation = mICount * -1;
                 nMonth.intercalary = true;

--- a/src/classes/simple-calendar-configuration.test.ts
+++ b/src/classes/simple-calendar-configuration.test.ts
@@ -71,7 +71,7 @@ describe('Simple Calendar Configuration Tests', () => {
         //@ts-ignore
         expect(opts.resizable).toBe(true);
         //@ts-ignore
-        expect(opts.width).toBe(960);
+        expect(opts.width).toBe(900);
         //@ts-ignore
         expect(opts.height).toBe(700);
         //@ts-ignore

--- a/src/classes/simple-calendar-configuration.ts
+++ b/src/classes/simple-calendar-configuration.ts
@@ -55,7 +55,7 @@ export class SimpleCalendarConfiguration extends FormApplication {
         options.resizable = true;
         options.tabs = [{navSelector: ".tabs", contentSelector: "form", initial: "yearSettings"}];
         options.height = 700;
-        options.width = 960;
+        options.width = 900;
         return options;
     }
 
@@ -63,7 +63,7 @@ export class SimpleCalendarConfiguration extends FormApplication {
      * Shows the application window
      */
     public showApp(){
-        this.render(true, {width: 500, height: 500});
+        this.render(true);
     }
 
     /**

--- a/src/classes/simple-calendar-notes.test.ts
+++ b/src/classes/simple-calendar-notes.test.ts
@@ -326,7 +326,7 @@ describe('Simple Calendar Notes Tests', () => {
         SimpleCalendarNotes.instance.editors['content'].mce = {getContent: ()=>{return 'a';},isNotDirty: false};
         SimpleCalendarNotes.instance.saveButtonClick(event);
         //@ts-ignore
-        expect(ui.notifications.warn).toHaveBeenCalledTimes(2);
+        expect(ui.notifications.warn).toHaveBeenCalledTimes(1);
 
         //@ts-ignore
         SimpleCalendarNotes.instance.element = {

--- a/src/classes/simple-calendar-notes.ts
+++ b/src/classes/simple-calendar-notes.ts
@@ -109,6 +109,7 @@ export class SimpleCalendarNotes extends FormApplication {
                 data.authorName = user.name;
             }
         }
+        console.log(this.editors['content']);
         return data;
     }
 
@@ -191,6 +192,7 @@ export class SimpleCalendarNotes extends FormApplication {
      */
     protected _updateObject(event: Event | JQuery.Event, formData: any): Promise<any> {
         (<Note>this.object).content = formData['content'];
+        Logger.debug('Update Object Called');
         this.richEditorSaved = true;
         return Promise.resolve(false);
     }
@@ -279,7 +281,8 @@ export class SimpleCalendarNotes extends FormApplication {
         let detailsEmpty = true;
         if(this.editors['content'] && this.editors['content'].mce){
             if(this.editors['content'].mce.getContent().trim() !== '' && !this.editors['content'].mce.isNotDirty){
-                detailsEmpty = false;
+                (<Note>this.object).content = this.editors['content'].mce.getContent().trim();
+                this.richEditorSaved = true;
             }
         } else {
             detailsEmpty = false;

--- a/src/classes/simple-calendar.test.ts
+++ b/src/classes/simple-calendar.test.ts
@@ -65,11 +65,13 @@ describe('Simple Calendar Class Tests', () => {
     test('Default Options', () => {
         const spy = jest.spyOn(Application, 'defaultOptions', 'get');
         const opts = SimpleCalendar.defaultOptions;
-        expect(Object.keys(opts).length).toBe(4); //Make sure no new properties have been added
+        expect(Object.keys(opts).length).toBe(5); //Make sure no new properties have been added
         expect(opts.template).toBe('modules/foundryvtt-simple-calendar/templates/calendar.html');
         expect(opts.title).toBe('FSC.Title');
         expect(opts.classes).toStrictEqual(["simple-calendar"]);
         expect(opts.resizable).toBe(true);
+        //@ts-ignore
+        expect(opts.height).toBe(475);
         expect(spy).toHaveBeenCalled()
     });
 
@@ -813,7 +815,7 @@ describe('Simple Calendar Class Tests', () => {
                 case SettingNames.YearConfiguration:
                     return {numericRepresentation: 0, prefix: '', postfix: ''};
                 case SettingNames.MonthConfiguration:
-                    return [[{numericRepresentation: 1, numberOfDays: 2, name: ''}]];
+                    return [[{numericRepresentation: 1, numberOfDays: "asd", numberOfLeapYearDays: "asd", name: ''}]];
                 case SettingNames.WeekdayConfiguration:
                     return [[{numericRepresentation: 0, name: ''}]];
                 case SettingNames.CurrentDate:

--- a/src/classes/simple-calendar.ts
+++ b/src/classes/simple-calendar.ts
@@ -71,6 +71,7 @@ export default class SimpleCalendar extends Application{
         options.title = "FSC.Title";
         options.classes = ["simple-calendar"];
         options.resizable = true;
+        options.height = 475;
         return options;
     }
 
@@ -639,7 +640,15 @@ export default class SimpleCalendar extends Application{
                 Logger.debug('Setting the months from data.');
                 for(let i = 0; i < monthData.length; i++){
                     if(Object.keys(monthData[i]).length){
-                        const newMonth = new Month(monthData[i].name, monthData[i].numericRepresentation, monthData[i].numberOfDays, monthData[i].numberOfLeapYearDays);
+                        let numDays = parseInt(monthData[i].numberOfDays.toString());
+                        let numLeapDays = monthData[i].numberOfLeapYearDays === undefined? 0 : parseInt(monthData[i].numberOfLeapYearDays.toString());
+                        if(isNaN(numDays)){
+                            numDays = 1;
+                        }
+                        if(isNaN(numLeapDays)){
+                            numLeapDays = 1;
+                        }
+                        const newMonth = new Month(monthData[i].name, monthData[i].numericRepresentation, numDays, numLeapDays);
                         newMonth.intercalary = monthData[i].intercalary;
                         newMonth.intercalaryInclude = monthData[i].intercalaryInclude;
                         this.currentYear.months.push(newMonth);

--- a/src/classes/weekday.test.ts
+++ b/src/classes/weekday.test.ts
@@ -23,7 +23,7 @@ describe('Weekday Class Tests', () => {
         expect(w.firstCharacter).toBe("");
         expect(w.numericRepresentation).toBe(0);
         expect(w2.name).toBe("asd");
-        expect(w2.firstCharacter).toBe("A");
+        expect(w2.firstCharacter).toBe("As");
         expect(w2.numericRepresentation).toBe(1);
 
     });

--- a/src/classes/weekday.ts
+++ b/src/classes/weekday.ts
@@ -30,9 +30,13 @@ export class Weekday {
      * @return {WeekdayTemplate}
      */
     toTemplate(): WeekdayTemplate{
+        let abbrv = this.name.substring(0,1).toUpperCase();
+        if(this.name.length > 1){
+            abbrv += this.name.substring(1,2).toLowerCase();
+        }
         return {
             name: this.name,
-            firstCharacter: this.name.substring(0,1).toUpperCase(),
+            firstCharacter: abbrv,
             numericRepresentation: this.numericRepresentation
         };
     }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -364,8 +364,8 @@ export namespace CalendarWeatherImport{
      */
     export interface Month {
         name: string;
-        length: number;
-        leapLength: number;
+        length: number | string;
+        leapLength: number | string;
         isNumbered: boolean;
         abbrev: string;
     }

--- a/src/module.json
+++ b/src/module.json
@@ -2,7 +2,7 @@
   "name": "foundryvtt-simple-calendar",
   "title": "Simple Calendar",
   "description": "A simple calendar module for keeping track of game days and events.",
-  "version": "1.2.0",
+  "version": "1.2.5",
   "author": "Dean Vigoren (Vigorator)",
   "minimumCoreVersion": "0.7.9",
   "compatibleCoreVersion": "0.7.9",

--- a/src/styles/configuration.scss
+++ b/src/styles/configuration.scss
@@ -7,11 +7,18 @@
     line-height: 32px;
     font-size: 16px;
     border-bottom: 1px solid #782e22;
+    justify-content: space-between;
+    flex-wrap: nowrap;
 
     .item{
       border: 1px solid transparent;
       border-top-left-radius: 5px;
       border-top-right-radius: 5px;
+      font-size: 14px;
+      font-weight: 600;
+      line-height: 1.25rem;
+      padding: 0.5rem 0.25rem;
+      flex: 0 1 125px;
       &.active{
         border-top-color: #782e22;
         border-left-color: #782e22;


### PR DESCRIPTION
Fixed an issue when importing from Calendar/Weather into Simple Calen…dar where the number of days and number of leap days would be saved as strings instead of numbers.

Adjusted the configuration tabs to be a smaller bolder font with a set width, new line height and padding. This will keep it looking better as the window is shrunk but also should keep it wide enough to not break on new lines.
Adjusted the height of the simple calendar view so that more events are visible.
Updated the adding/editing of a note so that the text editor does not need to be saved before saving the note. When saving the note the current content will be saved.
Updated weekday headings to show the first 2 characters to help distinguish between weekdays with the same starting character.

Closes #53 
Closes #51 
Closes #50 
Closes #47 
Closes #45