### PR TITLE
Bug Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## v1.2.34 - Bug Fixing
+
+- Fixed a bug where removing all phases from a moon would cause the calendar to no longer open.
+- Fixed an issue where the compact view clock would show when the show clock setting was unchecked. 
+- Fixed an issue where GM date and time controls would show when they.
+- Fixed an issue when time was advanced by other means (combat tracker or third party module) on maps with intercalary days. Simple Calendar would calculate the new date incorrectly.
+
 ## v1.2.30 - Compact View, Bug Fixes, QoL Improvements & Translations
 
 ### Compact View

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "foundryvtt-simple-calendar",
   "description": "A simple calendar module for keeping track of game days and events.",
-  "version": "1.2.30",
+  "version": "1.2.34",
   "author": "Dean Vigoren (vigorator)",
   "keywords": [
     "foundryvtt",

--- a/src/classes/handlebars-helpers.ts
+++ b/src/classes/handlebars-helpers.ts
@@ -46,7 +46,7 @@ export default class HandlebarsHelpers{
             let html = ''
             for(let i = 0; i < SimpleCalendar.instance.currentYear.moons.length; i++){
                 const mp = SimpleCalendar.instance.currentYear.moons[i].getMoonPhase(SimpleCalendar.instance.currentYear, 'visible', day);
-                if(mp.singleDay || day.selected || day.current){
+                if(mp && (mp.singleDay || day.selected || day.current)){
                     html += `<span class="moon-phase ${mp.icon}" title="${SimpleCalendar.instance.currentYear.moons[i].name} - ${mp.name}" style="background-color: ${SimpleCalendar.instance.currentYear.moons[i].color};"></span>`;
                 }
             }

--- a/src/classes/year.test.ts
+++ b/src/classes/year.test.ts
@@ -579,7 +579,7 @@ describe('Year Class Tests', () => {
         expect(year.secondsToDate(70)).toStrictEqual({year: 0, month: 0, day: 1, hour: 0, minute: 1, seconds: 10});
         expect(year.secondsToDate(3670)).toStrictEqual({year: 0, month: 0, day: 1, hour: 1, minute: 1, seconds: 10});
         expect(year.secondsToDate(90070)).toStrictEqual({year: 0, month: 0, day: 2, hour: 1, minute: 1, seconds: 10});
-        expect(year.secondsToDate(2682070)).toStrictEqual({year: 1, month: 0, day: 2, hour: 1, minute: 1, seconds: 10});
+        expect(year.secondsToDate(2682070)).toStrictEqual({year: 0, month: 1, day: 2, hour: 1, minute: 1, seconds: 10});
         year.months[1].intercalary = false;
         year.leapYearRule = new LeapYear();
         year.leapYearRule.rule = LeapYearRules.Gregorian;

--- a/src/classes/year.ts
+++ b/src/classes/year.ts
@@ -562,7 +562,7 @@ export default class Year {
         while(dayCount > 0){
             let isLeapYear = this.leapYearRule.isLeapYear(year);
             for(let i = 0; i < this.months.length; i ++){
-                if(!this.months[i].intercalary || (this.months[i].intercalary && this.months[i].intercalaryInclude)){
+                //if(!this.months[i].intercalary || (this.months[i].intercalary && this.months[i].intercalaryInclude)){
                     const daysInMonth = isLeapYear? this.months[i].numberOfLeapYearDays : this.months[i].numberOfDays;
                     month = i;
                     if(dayCount < daysInMonth) {
@@ -573,7 +573,7 @@ export default class Year {
                     if(dayCount <= 0){
                         break;
                     }
-                }
+                //}
             }
             if(dayCount > 0){
                 year++;

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,4 +21,4 @@ Hooks.on("updateCombat", SimpleCalendar.instance.combatUpdate.bind(SimpleCalenda
 Hooks.on("deleteCombat", SimpleCalendar.instance.combatDelete.bind(SimpleCalendar.instance));
 Hooks.on("pauseGame", SimpleCalendar.instance.gamePaused.bind(SimpleCalendar.instance));
 
-Logger.debugMode = true;
+//Logger.debugMode = true;

--- a/src/module.json
+++ b/src/module.json
@@ -2,7 +2,7 @@
   "name": "foundryvtt-simple-calendar",
   "title": "Simple Calendar",
   "description": "A simple calendar module for keeping track of game days and events.",
-  "version": "1.2.30",
+  "version": "1.2.34",
   "author": "Dean Vigoren (Vigorator)",
   "authors": [
     {

--- a/src/templates/calendar.html
+++ b/src/templates/calendar.html
@@ -19,28 +19,37 @@
         </div>
         <div class="current-date">
             {{#if isGM}}
+            {{#if currentYear.showDateControls}}
             <a class="prev fa fa-angle-left" data-type="day"></a>
+            {{/if}}
             {{/if}}
             <div class="date">
                 {{currentYear.selectedDayOfWeek}} {{currentYear.selectedDisplayMonth}} {{currentYear.selectedDisplayDay}}, {{currentYear.display}}
             </div>
             {{#if isGM}}
+            {{#if currentYear.showDateControls}}
             <a class="next fa fa-angle-right" data-type="day"></a>
             {{/if}}
+            {{/if}}
         </div>
+        {{#if currentYear.showClock}}
         <div class="current-time">
             <span class="clock {{clockClass}}"></span>
             <div class="time">
                 {{currentYear.currentTime.hour}}:{{currentYear.currentTime.minute}}:{{currentYear.currentTime.second}}
             </div>
             {{#if isPrimary}}
+            {{#if currentYear.showTimeControls}}
             <div class="time-controls">
                 <a class="time-start {{clockClass}} fa fa-play" title="{{localize 'FSC.Time.Start'}}"></a>
                 <a class="time-stop {{clockClass}} fa fa-stop" title="{{localize 'FSC.Time.Stop'}}"></a>
             </div>
             {{/if}}
+            {{/if}}
         </div>
+        {{/if}}
         {{#if isGM}}
+        {{#if currentYear.showTimeControls}}
         <div class="time-controls">
             <div class="selector" data-type="second" data-amount="1">{{localize 'FSC.One'}} {{localize 'FSC.SecondShorthand'}}</div>
             <div class="selector" data-type="second" data-amount="30">{{localize 'FSC.Thirty'}} {{localize 'FSC.SecondShorthand'}}</div>
@@ -48,6 +57,7 @@
             <div class="selector" data-type="minute" data-amount="5">{{localize 'FSC.Five'}} {{localize 'FSC.MinuteShorthand'}}</div>
             <div class="selector" data-type="hour" data-amount="1">{{localize 'FSC.One'}} {{localize 'FSC.HourShorthand'}}</div>
         </div>
+        {{/if}}
         {{/if}}
         {{#if compactViewShowNotes}}
         {{#if notes.length}}


### PR DESCRIPTION
Fixed a bug where removing all phases from a moon would cause the calendar to no longer open.

Fixed an issue where the compact view clock would show when the show clock setting was unchecked.
Fixed an issue where GM date and time controls would show when they.
Fixed an issue when time was advanced by other means (combat tracker or third party module) on maps with intercalary days. Simple Calendar would calculate the new date incorrectly.

Closes #75 
Closes #76 
Closes #77 