### PR TITLE
v1.2.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## v1.2.38 - Quality of Life Improvements and Bug Fixes
+
+### Quality of Live Improvements
+- Changed the tooltip for days with notes. If the day has 1 or 2 notes the tool tip will now show the title of the notes on that day instead of just the count. If there are 3 or more notes the tool tip will just show the number of notes on that day (like it does now).
+
+### Bug Fixes
+
+- Fixed an issue where about-time would be off by a day or more when changing the date in Simple Calendar.<br/>**IMPORTANT**: If you were impacted by this please follow these steps:
+  - Open the Simple Calendar configuration and click the save configuration button (This will fix part of the issue within Simple Calendar).
+  - Open the Simple Calendar configuration and under the General Settings tab click the "Export Into About-Time" button (This will update about-time with the fix).
+  - Change the day in Simple Calendar, move a day forward or backward. This will re-sync both modules.
+- Fixed an issue where Intercalary Days could not be set as the start of seasons or used for the moon's reference month.
+
 ## v1.2.35 - Bug Fix
 
 - Fixed a bug where users were unable to set the custom leap year value.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "foundryvtt-simple-calendar",
   "description": "A simple calendar module for keeping track of game days and events.",
-  "version": "1.2.35",
+  "version": "1.2.38",
   "author": "Dean Vigoren (vigorator)",
   "keywords": [
     "foundryvtt",

--- a/src/classes/handlebars-helpers.test.ts
+++ b/src/classes/handlebars-helpers.test.ts
@@ -37,9 +37,20 @@ describe('Handlebars Helpers Tests', () => {
             SimpleCalendar.instance.currentYear.months[0].visible = true;
             expect(HandlebarsHelpers.DayHasNotes(options)).toBe('');
             options.hash['day'].numericRepresentation = 2;
-            expect(HandlebarsHelpers.DayHasNotes(options)).toBe(`<span class="note-count" title="1 ">1</span>`);
+            expect(HandlebarsHelpers.DayHasNotes(options)).toBe(`<span class="note-count" title=":\n">1</span>`);
 
-            for(let i = 0; i < 99; i++){
+            SimpleCalendar.instance.notes = [];
+            for(let i = 0; i < 2; i++){
+                var n = new Note()
+                n.title = i.toString();
+                n.year = SimpleCalendar.instance.currentYear.numericRepresentation;
+                n.month = 1;
+                n.day = 2;
+                SimpleCalendar.instance.notes.push(n);
+            }
+            expect(HandlebarsHelpers.DayHasNotes(options)).toBe(`<span class="note-count" title=":\n0\n1">2</span>`);
+            SimpleCalendar.instance.notes = [];
+            for(let i = 0; i < 100; i++){
                 var n = new Note()
                 n.year = SimpleCalendar.instance.currentYear.numericRepresentation;
                 n.month = 1;

--- a/src/classes/handlebars-helpers.ts
+++ b/src/classes/handlebars-helpers.ts
@@ -28,7 +28,18 @@ export default class HandlebarsHelpers{
                 const notes = SimpleCalendar.instance.notes.filter(n => n.isVisible(year, month.numericRepresentation, day));
                 if(notes.length){
                     const count = notes.length < 100? notes.length : 99;
-                    return `<span class="note-count" title="${count} ${GameSettings.Localize('FSC.Configuration.General.Notes')}">${count}</span>`;
+                    let title = `${count} ${GameSettings.Localize('FSC.Configuration.General.Notes')}`;
+                    if(notes.length < 3){
+                        title = GameSettings.Localize('FSC.Configuration.General.Notes') + ':\n';
+                        for(let i = 0; i < notes.length; i++){
+                            if(i !== 0){
+                                title += '\n';
+                            }
+                            const nTitle = notes[i].title.replace(/"/g,'&quot;');
+                            title += `${nTitle}`;
+                        }
+                    }
+                    return `<span class="note-count" title="${title}">${count}</span>`;
                 }
             }
         }

--- a/src/classes/importer.ts
+++ b/src/classes/importer.ts
@@ -82,8 +82,12 @@ export default class Importer{
 
         const monthList: AboutTimeImport.MonthList = {};
         for(let i = 0; i < year.months.length; i++){
+            let leapYearDays = year.months[i].numberOfLeapYearDays;
+            if(year.leapYearRule.rule === LeapYearRules.None){
+                leapYearDays = year.months[i].numberOfDays;
+            }
             monthList[year.months[i].name] = {
-                days: [year.months[i].numberOfDays, year.months[i].numberOfLeapYearDays],
+                days: [year.months[i].numberOfDays, leapYearDays],
                 intercalary: year.months[i].intercalary
             };
         }

--- a/src/classes/month.test.ts
+++ b/src/classes/month.test.ts
@@ -76,7 +76,7 @@ describe('Month Class Tests', () => {
 
         //Intercalary days are represented by negative numbers, the template spits them out as 0
         const t2 = monthIc.toTemplate();
-        expect(t2.numericRepresentation).toBe(0);
+        expect(t2.numericRepresentation).toBe(-1);
     });
 
     test('Clone', () => {

--- a/src/classes/month.ts
+++ b/src/classes/month.ts
@@ -123,7 +123,7 @@ export default class Month {
         return {
             display: this.getDisplayName(),
             name: this.name,
-            numericRepresentation: this.numericRepresentation < 0? 0 : this.numericRepresentation,
+            numericRepresentation: this.numericRepresentation,
             numericRepresentationOffset: this.numericRepresentationOffset,
             current: this.current,
             visible: this.visible,

--- a/src/classes/simple-calendar-configuration.test.ts
+++ b/src/classes/simple-calendar-configuration.test.ts
@@ -10,14 +10,14 @@ import "../../__mocks__/dialog";
 
 import {SimpleCalendarConfiguration} from "./simple-calendar-configuration";
 import Year from "./year";
-import SpyInstance = jest.SpyInstance;
-import Mock = jest.Mock;
 import Month from "./month";
 import {Weekday} from "./weekday";
 import {Logger} from "./logging";
 import {LeapYearRules, MoonIcons, MoonYearResetOptions} from "../constants";
 import Season from "./season";
 import Moon from "./moon";
+import SpyInstance = jest.SpyInstance;
+import Mock = jest.Mock;
 
 jest.mock('./importer');
 
@@ -641,6 +641,13 @@ describe('Simple Calendar Configuration Tests', () => {
         (<HTMLInputElement>event.currentTarget).value = '20';
         SimpleCalendarConfiguration.instance.inputChange(event);
         expect((<Year>SimpleCalendarConfiguration.instance.object).months[0].numberOfDays).toBe(20);
+        expect((<Year>SimpleCalendarConfiguration.instance.object).months[0].numberOfLeapYearDays).toBe(20);
+        //Test all attributes for month day change with leapyear rules set
+        (<Year>SimpleCalendarConfiguration.instance.object).leapYearRule.rule = LeapYearRules.Gregorian;
+        (<HTMLInputElement>event.currentTarget).value = '19';
+        SimpleCalendarConfiguration.instance.inputChange(event);
+        expect((<Year>SimpleCalendarConfiguration.instance.object).months[0].numberOfDays).toBe(19);
+        expect((<Year>SimpleCalendarConfiguration.instance.object).months[0].numberOfLeapYearDays).toBe(20);
 
         //Test intercalary change
         //@ts-ignore
@@ -676,7 +683,7 @@ describe('Simple Calendar Configuration Tests', () => {
         (<HTMLElement>event.currentTarget).classList.remove('month-intercalary-include');
         (<HTMLElement>event.currentTarget).classList.add('no');
         SimpleCalendarConfiguration.instance.inputChange(event);
-        expect(console.debug).toHaveBeenCalledTimes(47);
+        expect(console.debug).toHaveBeenCalledTimes(50);
 
     });
 
@@ -1006,6 +1013,11 @@ describe('Simple Calendar Configuration Tests', () => {
         expect((<Year>SimpleCalendarConfiguration.instance.object).numericRepresentation).toBe(2);
         expect((<Year>SimpleCalendarConfiguration.instance.object).selectedYear).toBe(2);
         expect((<Year>SimpleCalendarConfiguration.instance.object).visibleYear).toBe(2);
+
+        (<Year>SimpleCalendarConfiguration.instance.object).leapYearRule.rule = LeapYearRules.Gregorian;
+        await SimpleCalendarConfiguration.instance.saveClick(event);
+        expect(game.settings.set).toHaveBeenCalledTimes(16);
+        expect(closeSpy).toHaveBeenCalledTimes(2);
     });
 
     test('Overwrite Confirmation Yes', async () => {

--- a/src/classes/simple-calendar-configuration.ts
+++ b/src/classes/simple-calendar-configuration.ts
@@ -1052,6 +1052,7 @@ export class SimpleCalendarConfiguration extends FormApplication {
                         const month = parseInt(value);
                         if(!isNaN(month)){
                             (<Year>this.object).seasons[index].startingMonth = month;
+                            (<Year>this.object).seasons[index].startingDay = 1;
                         }
                     } else if(cssClass === 'season-day' && (<Year>this.object).seasons.length > index){
                         const day = parseInt(value);
@@ -1071,6 +1072,9 @@ export class SimpleCalendarConfiguration extends FormApplication {
                         let days = parseInt(value);
                         if(!isNaN(days) && days !== (<Year>this.object).months[index].days.length){
                             (<Year>this.object).months[index].numberOfDays = days;
+                            if((<Year>this.object).leapYearRule.rule === LeapYearRules.None){
+                                (<Year>this.object).months[index].numberOfLeapYearDays = days;
+                            }
                             this.updateMonthDays((<Year>this.object).months[index]);
                         }
                     } else if (cssClass === 'month-intercalary' && (<Year>this.object).months.length > index){
@@ -1133,6 +1137,7 @@ export class SimpleCalendarConfiguration extends FormApplication {
                         const month = parseInt(value);
                         if(!isNaN(month)){
                             (<Year>this.object).moons[index].firstNewMoon.month = month;
+                            (<Year>this.object).moons[index].firstNewMoon.day = 1;
                         }
                     } else if(cssClass === 'moon-day' && (<Year>this.object).moons.length > index){
                         const day = parseInt(value);
@@ -1257,6 +1262,12 @@ export class SimpleCalendarConfiguration extends FormApplication {
     public async saveClick(e: Event) {
         e.preventDefault();
         try{
+            //If there is no leap year rule set ensure months leap year and normal days match
+            if((<Year>this.object).leapYearRule.rule === LeapYearRules.None){
+                for(let i = 0; i < (<Year>this.object).months.length; i++){
+                    (<Year>this.object).months[i].numberOfLeapYearDays = (<Year>this.object).months[i].numberOfDays;
+                }
+            }
             // Update the general Settings
             (<Year>this.object).generalSettings.gameWorldTimeIntegration = <GameWorldTimeIntegrations>(<HTMLInputElement>document.getElementById("scGameWorldTime")).value;
             await GameSettings.SaveGeneralSettings((<Year>this.object).generalSettings);

--- a/src/classes/year.ts
+++ b/src/classes/year.ts
@@ -650,7 +650,7 @@ export default class Year {
 
         const month = this.getMonth('visible');
         if(month){
-            currentMonth = month.numericRepresentation;
+            currentMonth = this.months.findIndex(m=> m.numericRepresentation === month.numericRepresentation);
             const day = month.getDay('selected') || month.getDay();
             if(day){
                 currentDay = day.numericRepresentation;
@@ -658,12 +658,13 @@ export default class Year {
                 currentDay = 1;
             }
         }
-        if(currentDay > 0 && currentMonth > 0){
+        if(currentDay > 0 && currentMonth >= 0){
             let currentSeason: Season | null = null;
             for(let i = 0; i < this.seasons.length; i++){
-                if(this.seasons[i].startingMonth === currentMonth && this.seasons[i].startingDay <= currentDay){
+                const seasonMonthIndex = this.months.findIndex(m => m.numericRepresentation === this.seasons[i].startingMonth);
+                if(seasonMonthIndex === currentMonth && this.seasons[i].startingDay <= currentDay){
                     currentSeason = this.seasons[i];
-                } else if (this.seasons[i].startingMonth < currentMonth){
+                } else if (seasonMonthIndex < currentMonth){
                     currentSeason = this.seasons[i];
                 }
             }

--- a/src/module.json
+++ b/src/module.json
@@ -2,7 +2,7 @@
   "name": "foundryvtt-simple-calendar",
   "title": "Simple Calendar",
   "description": "A simple calendar module for keeping track of game days and events.",
-  "version": "1.2.35",
+  "version": "1.2.38",
   "author": "Dean Vigoren (Vigorator)",
   "authors": [
     {

--- a/src/templates/calendar-config.html
+++ b/src/templates/calendar-config.html
@@ -194,7 +194,7 @@
                         <div style="text-align: center;">
                             <input class="month-intercalary" value="{{intercalary}}" type="checkbox" data-index="{{@index}}" title="{{localize 'FSC.Configuration.Month.IntercalaryHelp'}}" {{#if intercalary}}checked="checked"{{/if}} />
                         </div>
-                        <div class="month-number">{{#if numericRepresentation}}{{numericRepresentation}}{{else}}IC{{/if}}</div>
+                        <div class="month-number">{{#if (gt numericRepresentation 0)}}{{numericRepresentation}}{{else}}IC{{/if}}</div>
                         <div>
                             {{#if showAdvanced}}
                             <a class="month-show-advanced" data-index="{{@index}}"><span class="fa fa-chevron-up"></span> {{localize 'FSC.HideAdvanced'}}</a>


### PR DESCRIPTION
Fixed an issue with the configuration and months that would have a different number of leap year days when the leap year rule was set to "None". This would cause the sync with about-time to be off by the number of days equal to how many leap year days difference was in a year.

Fixed a bug where users were unable to set the start month of a season or the moons first new moon month to an intercalary month.
Fixed an issue where determining the season for an intercalary month would fail.
Expanded the tool tip for days with notes to include the note titles if there were 2 or less notes on that day.

Closes #83 
Closes #84 
Closes #89 