### PR TITLE
v1.2.71

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## v1.2.71 - API Bug Fixing
+
+- Fixed a bug with the new API timestampPlusInterval function that would incorrectly add a day when it shouldn't.
+- Fixed a bug with the new API timestampPlusInterval function where if the time variables added up to be more seconds than in a day, the day would not advance.
+- Fixed a bug with the new API timestampToDate function where the day of the week would be incorrectly calculated.
+- Standardized the naming of the parameters and variables of the different API functions so results can be directly passed from one into another.
+
 ## v1.2.67 - Translations, Macro/API Changes, Bug Fixes
 
 ### Macro/API Changes

--- a/docs/API.md
+++ b/docs/API.md
@@ -41,23 +41,23 @@ The interval object returned has the following properties
 
 Property|Type|Default Value|Description
 ---------|-----|-------------|-----------
-years|Number|0|The number of years in the passed in seconds
-months|Number|0|The number of months in the passed in seconds (month lengths are averaged out between all of the months so this may not be 100% accurate)
-days|Number|0|The number of days in the passed in seconds
-hours|Number|0|The number of hours in the passed in seconds
-minutes|Number|0|The number of minutes in the passed in seconds
-seconds|Number|0|The number of remaining seconds from the passed in seconds
+year|Number|0|The number of years in the passed in seconds
+month|Number|0|The number of months in the passed in seconds (month lengths are averaged out between all of the months so this may not be 100% accurate)
+day|Number|0|The number of days in the passed in seconds
+hour|Number|0|The number of hours in the passed in seconds
+minute|Number|0|The number of minutes in the passed in seconds
+second|Number|0|The number of remaining seconds from the passed in seconds
 
 ### Examples
 
 ```javascript
 //Assuming a Gregorian Calendar
-SimpleCalendar.api.secondsToInterval(3600); //Returns {years: 0, months: 0, days: 0, hours: 1, minutes: 0, seconds: 0}
-SimpleCalendar.api.secondsToInterval(3660); //Returns {years: 0, months: 0, days: 0, hours: 1, minutes: 1, seconds: 0}
-SimpleCalendar.api.secondsToInterval(86400); //Returns {years: 0, months: 0, days: 1, hours: 0, minutes: 0, seconds: 0}
-SimpleCalendar.api.secondsToInterval(604800); //Returns {years: 0, months: 0, days: 7, hours: 0, minutes: 0, seconds: 0}
-SimpleCalendar.api.secondsToInterval(2629743); //Returns {years: 0, months: 1, days: 0, hours: 10, minutes: 29, seconds: 3}
-SimpleCalendar.api.secondsToInterval(31556926); //Returns {years: 1, months: 0, days: 0, hours: 5, minutes: 48, seconds: 46}
+SimpleCalendar.api.secondsToInterval(3600); //Returns {year: 0, month: 0, day: 0, hour: 1, minute: 0, second 0}
+SimpleCalendar.api.secondsToInterval(3660); //Returns {year: 0, month: 0, day: 0, hour: 1, minute: 1, second: 0}
+SimpleCalendar.api.secondsToInterval(86400); //Returns {year: 0, month: 0, day: 1, hour: 0, minute: 0, second: 0}
+SimpleCalendar.api.secondsToInterval(604800); //Returns {year: 0, month: 0, day: 7, hour: 0, minute: 0, second: 0}
+SimpleCalendar.api.secondsToInterval(2629743); //Returns {year: 0, month: 1, day: 0, hour: 10, minute: 29, second: 3}
+SimpleCalendar.api.secondsToInterval(31556926); //Returns {year: 1, month: 0, day: 0, hour: 5, minute: 48, second: 46}
 ```
 
 ## `SimpleCalendar.api.showCalendar(date)`
@@ -68,7 +68,7 @@ Will open up Simple Calendar to the current date, or the passed in date.
 
 Parameter|Type|Default Value|Description
 ---------|-----|-------------|-----------
-date|object or null|null|A date object (eg `{year:2021, month: 4, 12}`) with the year, month and day set to the date to be visible when the calendar is opened.<br>**Important**: The month is index based so January would be 0.
+date|object or null|null|A date object (eg `{year:2021, month: 4, day: 12}`) with the year, month and day set to the date to be visible when the calendar is opened.<br>**Important**: The month is index based so January would be 0.
 
 ### Examples
 ```javascript
@@ -97,16 +97,16 @@ Returns the current timestamp plus the passed in interval amount.
 Parameter|Type|Default Value|Description
 ---------|-----|-------------|-----------
 timestamp|Number| No Default |The timestamp (in seconds) to have the interval added too.
-interval|Object|No Default|The interval objects properties are all optional so only those needed have to be set.<br/>A full object looks like this ```{years:0, months:0, days: 0, hours: 0, minutes: 0, seconds: 0}```<br/>Where each property is how many of that interval to increase the passed in timestamp by.
+interval|Object|No Default|The interval objects properties are all optional so only those needed have to be set.<br/>A full object looks like this ```{year:0, month:0, day: 0, hour: 0, minute: 0, second: 0}```<br/>Where each property is how many of that interval to increase the passed in timestamp by.
 
 ### Examples
 
 ```javascript
-let newTime = SimpleCalendar.api.timestampPlusInterval(0, {days: 1});
+let newTime = SimpleCalendar.api.timestampPlusInterval(0, {day: 1});
 console.log(newTime); // this will be 0 + the number of seconds in 1 day. For most calendars this will be 86400
 
 // Assuming Gregorian Calendar with the current date of June 1, 2021
-newTime = SimpleCalendar.api.timestampPlusInterval(1622505600, {months: 1, days: 1});
+newTime = SimpleCalendar.api.timestampPlusInterval(1622505600, {month: 1, day: 1});
 console.log(newTime); // This will be the number of seconds that equal July 2nd 2021
 ```
 
@@ -132,9 +132,9 @@ month|Number|0|The index of the month represented in the timestamp.
 monthName|String|""|The name of the month.
 day|Number|0|The day of the month represented in the timestamp.
 dayOfTheWeek|Number|0|The day of the week the day falls on.
-hours|Number|0|The hour represented in the timestamp.
-minutes|Number|0|The minute represented in the timestamp.
-seconds|Number|0|The seconds represented in the timestamp.
+hour|Number|0|The hour represented in the timestamp.
+minute|Number|0|The minute represented in the timestamp.
+second|Number|0|The seconds represented in the timestamp.
 yearZero|Number|0|What is considered as year zero when doing timestamp calculations.
 weekdays|String Array|[]|A list of weekday names.
 
@@ -148,11 +148,11 @@ console.log(scDate);
 {
     day: 1,
     dayOfTheWeek: 6,
-    hours: 0,
-    minutes: 0,
+    hour: 0,
+    minute: 0,
     month: 5,
     monthName: "June",
-    seconds: 0,
+    second: 0,
     weekdays: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"],
     year: 2021,
     yearName: "",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "foundryvtt-simple-calendar",
   "description": "A simple calendar module for keeping track of game days and events.",
-  "version": "1.2.67",
+  "version": "1.2.71",
   "author": "Dean Vigoren (vigorator)",
   "keywords": [
     "foundryvtt",

--- a/src/classes/api.test.ts
+++ b/src/classes/api.test.ts
@@ -17,6 +17,7 @@ import Month from "./month";
 import {Weekday} from "./weekday";
 import {LeapYearRules} from "../constants";
 import SpyInstance = jest.SpyInstance;
+import Macros from "./macros";
 
 
 describe('API Class Tests', () => {
@@ -28,7 +29,7 @@ describe('API Class Tests', () => {
         renderSpy.mockClear();
         year = new Year(1);
         year.months.push(new Month('M1', 1, 0, 30));
-        year.months.push(new Month('M2', 2, 0, 30));
+        year.months.push(new Month('M2', 2, 0, 30, 31));
         year.months[0].current = true;
         year.months[0].days[0].current = true;
     });
@@ -36,33 +37,43 @@ describe('API Class Tests', () => {
     test('Timestamp', () => {
         expect(API.timestamp()).toBe(0);
         SimpleCalendar.instance.currentYear = year;
-        expect(API.timestamp()).toBe(5184000);
+        expect(API.timestamp()).toBe(5270400);
     });
 
     test('Timestamp Plus Interval', () => {
         expect(API.timestampPlusInterval(0, {})).toBe(0);
         SimpleCalendar.instance.currentYear = year;
-        expect(API.timestampPlusInterval(0, {seconds: 1})).toBe(1);
-        expect(API.timestampPlusInterval(0, {minutes: 1})).toBe(60);
-        expect(API.timestampPlusInterval(0, {hours: 1})).toBe(3600);
-        expect(API.timestampPlusInterval(0, {hours: 1, minutes: 1, seconds: 6})).toBe(3666);
-        expect(API.timestampPlusInterval(0, {days: 1})).toBe(86400);
-        expect(API.timestampPlusInterval(0, {months: 1})).toBe(2592000);
-        expect(API.timestampPlusInterval(0, {years: 1})).toBe(5184000);
+        year.yearZero = 0;
+        expect(API.timestampPlusInterval(0, {second: 1})).toBe(1);
+        expect(API.timestampPlusInterval(0, {minute: 1})).toBe(60);
+        expect(API.timestampPlusInterval(0, {hour: 1})).toBe(3600);
+        expect(API.timestampPlusInterval(0, {hour: 1, minute: 1, second: 6})).toBe(3666);
+        expect(API.timestampPlusInterval(0, {day: 1})).toBe(86400);
+        expect(API.timestampPlusInterval(0, {month: 1})).toBe(2592000);
+        expect(API.timestampPlusInterval(0, {year: 1})).toBe(5270400);
+
+        year.leapYearRule.rule = LeapYearRules.Gregorian;
+        expect(API.timestampPlusInterval(0, {day: 0})).toBe(0);
+        expect(API.timestampPlusInterval(0, {})).toBe(0);
+
+        expect(API.timestampPlusInterval(1623077754, {day: 0})).toBe(1623077754);
+        expect(API.timestampPlusInterval(1623077754, {day: 1})).toBe(1623164154);
+
+        expect(API.timestampPlusInterval(0, {second: 86401})).toBe(86401);
     });
 
     test('Timestamp to Date', () => {
-        expect(API.timestampToDate(3600)).toStrictEqual({year: 0, month: 0, day: 0, dayOfTheWeek: 0, hours: 0, minutes: 0, seconds: 0, monthName: "", yearName: "", yearZero: 0, weekdays: []});
+        expect(API.timestampToDate(3600)).toStrictEqual({year: 0, month: 0, day: 0, dayOfTheWeek: 0, hour: 0, minute: 0, second: 0, monthName: "", yearName: "", yearZero: 0, weekdays: []});
         SimpleCalendar.instance.currentYear = year;
         year.weekdays.push(new Weekday(1, 'W1'));
-        expect(API.timestampToDate(3600)).toStrictEqual({year: 0, month: 0, day: 1, dayOfTheWeek: 0, hours: 1, minutes: 0, seconds: 0, monthName: "M1", yearName: "", yearZero: 0, weekdays: ["W1"]});
-        expect(API.timestampToDate(5184000)).toStrictEqual({year: 1, month: 0, day: 1, dayOfTheWeek: 0, hours: 0, minutes: 0, seconds: 0, monthName: "M1", yearName: "", yearZero: 0, weekdays: ["W1"]});
+        expect(API.timestampToDate(3600)).toStrictEqual({year: 0, month: 0, day: 1, dayOfTheWeek: 0, hour: 1, minute: 0, second: 0, monthName: "M1", yearName: "", yearZero: 0, weekdays: ["W1"]});
+        expect(API.timestampToDate(5184000)).toStrictEqual({year: 1, month: 0, day: 1, dayOfTheWeek: 0, hour: 0, minute: 0, second: 0, monthName: "M1", yearName: "", yearZero: 0, weekdays: ["W1"]});
     });
 
     test('Seconds To Interval', () => {
-        expect(API.secondsToInterval(3600)).toStrictEqual({ years: 0, months: 0, days: 0, hours: 0, minutes: 0, seconds: 0});
+        expect(API.secondsToInterval(3600)).toStrictEqual({ year: 0, month: 0, day: 0, hour: 0, minute: 0, second: 0});
         SimpleCalendar.instance.currentYear = year;
-        expect(API.secondsToInterval(3600)).toStrictEqual({ years: 0, months: 0, days: 0, hours: 1, minutes: 0, seconds: 0});
+        expect(API.secondsToInterval(3600)).toStrictEqual({ year: 0, month: 0, day: 0, hour: 1, minute: 0, second: 0});
     });
 
     test('Clock Status', () => {
@@ -93,6 +104,40 @@ describe('API Class Tests', () => {
         year.leapYearRule.rule = LeapYearRules.Gregorian
         API.showCalendar({year: 4, month: -1, day: -1});
         expect(renderSpy).toHaveBeenCalledTimes(5);
+    });
+
+    test('Change Date', () => {
+        Macros.changeDateTime();
+        expect(renderSpy).toHaveBeenCalledTimes(0);
+
+        //@ts-ignore
+        game.user.isGM = true;
+        SimpleCalendar.instance.currentYear = year;
+
+        API.changeDate({});
+        expect(renderSpy).toHaveBeenCalledTimes(0);
+
+        API.changeDate({year: 1});
+        expect(renderSpy).toHaveBeenCalledTimes(1);
+        expect(year.numericRepresentation).toBe(2);
+
+        API.changeDate({month: 1});
+        expect(renderSpy).toHaveBeenCalledTimes(2);
+        expect(year.getMonth()?.numericRepresentation).toBe(2);
+
+        API.changeDate({day: 1});
+        expect(renderSpy).toHaveBeenCalledTimes(3);
+        expect(year.getMonth()?.getDay()?.numericRepresentation).toBe(2);
+
+        API.changeDate({second: 1});
+        expect(renderSpy).toHaveBeenCalledTimes(4);
+        expect(year.time.seconds).toBe(1);
+
+        API.changeDate({second: 86401});
+        expect(renderSpy).toHaveBeenCalledTimes(5);
+        expect(year.getMonth()?.getDay()?.numericRepresentation).toBe(3);
+        expect(year.time.seconds).toBe(2);
+
     });
 
 });

--- a/src/classes/macros.test.ts
+++ b/src/classes/macros.test.ts
@@ -102,30 +102,11 @@ describe('Macros Tests', () => {
     test('Change Date Time', () => {
         Macros.changeDateTime();
         expect(renderSpy).toHaveBeenCalledTimes(0);
-
         //@ts-ignore
         game.user.isGM = true;
-        Macros.changeDateTime();
-        expect(renderSpy).toHaveBeenCalledTimes(0);
-        expect(console.error).toHaveBeenCalledTimes(1);
-
         SimpleCalendar.instance.currentYear = y;
-        Macros.changeDateTime();
-        expect(renderSpy).toHaveBeenCalledTimes(0);
-        expect(console.error).toHaveBeenCalledTimes(1);
-        expect(y.numericRepresentation).toBe(0);
-        expect(y.months[0].current).toBe(true);
-        expect(y.months[0].days[0].current).toBe(true);
-        expect(y.time.seconds).toBe(0);
-
-        Macros.changeDateTime(1,1,1,1,1,1);
+        Macros.changeDateTime(10);
         expect(renderSpy).toHaveBeenCalledTimes(1);
-        expect(console.error).toHaveBeenCalledTimes(1);
-        expect(y.numericRepresentation).toBe(1);
-        expect(y.months[1].current).toBe(true);
-        expect(y.months[1].days[1].current).toBe(true);
-        expect(y.time.seconds).toBe(3661);
-
         //@ts-ignore
         game.user.isGM = false;
     });

--- a/src/classes/macros.ts
+++ b/src/classes/macros.ts
@@ -1,7 +1,6 @@
 import {Logger} from "./logging";
 import SimpleCalendar from "./simple-calendar";
 import {GameSettings} from "./game-settings";
-import {SimpleCalendarSocket} from "../interfaces";
 import API from "./api";
 
 export default class Macros {
@@ -105,44 +104,7 @@ export default class Macros {
      * @param {number} [years=0] The number of years to change the time by, can be any amount negative or positive.
      */
     public static changeDateTime(seconds: number = 0, minutes: number = 0, hours: number = 0, days: number = 0, months: number = 0, years: number = 0){
-        if(GameSettings.IsGm()){
-            if(SimpleCalendar.instance && SimpleCalendar.instance.currentYear){
-                let timeChange = false;
-                let dateChange = false;
-                if(seconds !== 0){
-                    SimpleCalendar.instance.currentYear.changeTime(true, 'second', seconds);
-                    timeChange = true;
-                }
-                if(minutes !== 0){
-                    SimpleCalendar.instance.currentYear.changeTime(true, 'minute', minutes);
-                    timeChange = true;
-                }
-                if(hours !== 0){
-                    SimpleCalendar.instance.currentYear.changeTime(true, 'hour', hours);
-                    timeChange = true;
-                }
-                if(months !== 0){
-                    SimpleCalendar.instance.currentYear.changeMonth(months, 'current');
-                    dateChange = true;
-                }
-                if(days !== 0){
-                    SimpleCalendar.instance.currentYear.changeDay(days, 'current');
-                    dateChange = true;
-                }
-                if(years !== 0){
-                    SimpleCalendar.instance.currentYear.changeYear(years, !dateChange, 'current');
-                    dateChange = true;
-                }
-                if(dateChange || timeChange){
-                    GameSettings.SaveCurrentDate(SimpleCalendar.instance.currentYear).catch(Logger.error);
-                    SimpleCalendar.instance.currentYear.syncTime().catch(Logger.error);
-                    SimpleCalendar.instance.updateApp();
-                }
-            } else {
-                Logger.error('The current year is not defined, can not use macro');
-            }
-        } else {
-            GameSettings.UiNotification(GameSettings.Localize('FSC.Warn.Macros.GMUpdate'), 'warn');
-        }
+        Logger.warn(`The SimpleCalendar.changeDateTime function has been depreciated. Please update to use the SimpleCalendar.api.changeDate() function.`);
+        API.changeDate({year: years, month: months, day: days, hour: hours, minute: minutes, second: seconds});
     }
 }

--- a/src/classes/year.test.ts
+++ b/src/classes/year.test.ts
@@ -673,16 +673,16 @@ describe('Year Class Tests', () => {
         year.months.push(month);
         year.months.push(new Month("Test 2", 2, 0, 30, 30));
         year.months.push(new Month("Test 3", 3, 0, 30, 30));
-        expect(year.secondsToInterval(6)).toStrictEqual({years: 0, months: 0, days: 0, hours: 0, minutes: 0, seconds: 6});
-        expect(year.secondsToInterval(66)).toStrictEqual({years: 0, months: 0, days: 0, hours: 0, minutes: 1, seconds: 6});
-        expect(year.secondsToInterval(3666)).toStrictEqual({years: 0, months: 0, days: 0, hours: 1, minutes: 1, seconds: 6});
-        expect(year.secondsToInterval(86400)).toStrictEqual({years: 0, months: 0, days: 1, hours: 0, minutes: 0, seconds: 0});
-        expect(year.secondsToInterval(2592000)).toStrictEqual({years: 0, months: 1, days: 0, hours: 0, minutes: 0, seconds: 0});
-        expect(year.secondsToInterval(7776000)).toStrictEqual({years: 1, months: 0, days: 0, hours: 0, minutes: 0, seconds: 0});
+        expect(year.secondsToInterval(6)).toStrictEqual({year: 0, month: 0, day: 0, hour: 0, minute: 0, second: 6});
+        expect(year.secondsToInterval(66)).toStrictEqual({year: 0, month: 0, day: 0, hour: 0, minute: 1, second: 6});
+        expect(year.secondsToInterval(3666)).toStrictEqual({year: 0, month: 0, day: 0, hour: 1, minute: 1, second: 6});
+        expect(year.secondsToInterval(86400)).toStrictEqual({year: 0, month: 0, day: 1, hour: 0, minute: 0, second: 0});
+        expect(year.secondsToInterval(2592000)).toStrictEqual({year: 0, month: 1, day: 0, hour: 0, minute: 0, second: 0});
+        expect(year.secondsToInterval(7776000)).toStrictEqual({year: 1, month: 0, day: 0, hour: 0, minute: 0, second: 0});
 
-        expect(year.secondsToInterval(2505600)).toStrictEqual({years: 0, months: 0, days: 29, hours: 0, minutes: 0, seconds: 0});
-        expect(year.secondsToInterval(2591999)).toStrictEqual({years: 0, months: 0, days: 29, hours: 23, minutes: 59, seconds: 59});
-        expect(year.secondsToInterval(5184000)).toStrictEqual({years: 0, months: 2, days: 0, hours: 0, minutes: 0, seconds: 0});
+        expect(year.secondsToInterval(2505600)).toStrictEqual({year: 0, month: 0, day: 29, hour: 0, minute: 0, second: 0});
+        expect(year.secondsToInterval(2591999)).toStrictEqual({year: 0, month: 0, day: 29, hour: 23, minute: 59, second: 59});
+        expect(year.secondsToInterval(5184000)).toStrictEqual({year: 0, month: 2, day: 0, hour: 0, minute: 0, second: 0});
     });
 
     test('Update Time', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ Hooks.on('ready', () => {
         setDateTime: Macros.setDateTime,
         changeDateTime: Macros.changeDateTime,
         api:{
+            changeDate: API.changeDate,
             clockStatus: API.clockStatus,
             secondsToInterval: API.secondsToInterval,
             showCalendar: API.showCalendar,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -338,12 +338,12 @@ export interface DateTimeParts {
 }
 
 export interface DateTimeIntervals {
-    years?: number;
-    months?: number;
-    days?: number;
-    hours?: number;
-    minutes?: number;
-    seconds?: number;
+    year?: number;
+    month?: number;
+    day?: number;
+    hour?: number;
+    minute?: number;
+    second?: number;
 }
 
 /**

--- a/src/module.json
+++ b/src/module.json
@@ -2,7 +2,7 @@
   "name": "foundryvtt-simple-calendar",
   "title": "Simple Calendar",
   "description": "A simple calendar module for keeping track of game days and events.",
-  "version": "1.2.67",
+  "version": "1.2.71",
   "author": "Dean Vigoren (Vigorator)",
   "authors": [
     {


### PR DESCRIPTION
Fixed a bug with the calculation of leap years for years that happen before the first leap year.

Fixed a bug where the timestampPlusInterval function would not add days when the passed in seconds totaled to more than 1 day.
Fixed a bug where the timestampToDate function would return the wrong day of the week.
Standardized the naming of the parameters and return from the API functions so they can be passed into one another.
Moved the "changeDateTime" macro functionality over to the API class.

Updated the unit tests.