### PR TITLE
Big change list.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Change Log
 
+## v1.2.85 - New Clock, API Changes and as always more Bug Fixing
+
+### New Clock
+
+The old clock in Simple Calendar was very basic and not very good. I have removed that clock and re-written the entire thing which should provide a much nicer experience.
+The clock now functions as follows:
+
+- The time will now update every second for all players.
+- Every 10 seconds all players time will sync with the primary GM's time. This is to mitigate any time "wandering" that may happen.
+- The time can still be manually updated by those with permission while the clock is running.
+- For every second that passes, the time updates by the amount in the configuration setting [Game Seconds Per Real Life Seconds](./docs/Configuration.md#time-settings) under the time seconds.
+- If the GM disconnects while the clock is running, when they reconnect all the players clocks will stop running and be updated to the time when the GM disconnected.
+
+It is important to note that while the clock does its best to keep everyone on the same time if a player or GM has a high latency to the server (greater than one to two seconds) then the time may be visually off between the GM and the players. The Primary GM's time is considered correct and all other players will use that time.
+
+### API Changes
+
+- Changed the API showCalendar function to accept an additional parameter compact. Which, if set to true will open the calendar in compact mode.
+- Changed the API setDate function so that any time options that were not specified in passed in parameter will default to the current value. Eg If no year is specified the current year will be used.
+- Added a new API function, dateToTimestamp. This function will take in a date object and convert it to a timestamp.
+- Added a new API function, isPrimaryGM. This function will return if the current user is the primary GM. There is a 5-second delay from when a user joins to when they can be assigned the primary GM, this is to check for other primary GMs before taking over.
+- Added a hook that fires when the user is selected as the primary GM.
+- Added new API functions, startClock and stopClock. These functions will start/stop the built-in clock. Only the Primary GM can run the clock.
+
+### Bug Fixes
+
+- Fixed a bug when dealing with negative timestamps and negative years.
+- Fixed a bug where if the time updated while you were viewing another month, the calendar would update to view the month of the current date.
+- Fixed an issue with the API timestampToDate function that didn't account for the PF2E system.
+- Fixed an issue with the API timestampPlusInterval function that didn't account for the PF2E system.
+- Fixed a bug where occasionally the last day of the month would have a value of -1.
+
 ## v1.2.73 - API Bug Fixing
 
 ### Bug Fixes

--- a/docs/API.md
+++ b/docs/API.md
@@ -119,6 +119,42 @@ const status = SimpleCalendar.api.clockStatus();
 console.log(status); // {started: false, stopped: true, paused: false}
 ```
 
+## `SimpleCalendar.api.dateToTimestamp(date)`
+
+Will convert that passed in date object to a timestamp.
+
+### Parameters
+
+Parameter|Type|Default Value|Description
+---------|-----|-------------|-----------
+date|object or null|null|A date object (eg `{year:2021, month: 4, day: 12, hour: 0, mintue: 0, second: 0}`) with the parameters set to the date that should be converted to a timestamp. Any missing parameters will default to the current date value for that parameter.<br>**Important**: The month and day are index based so January would be 0 and the first day of the month will also be 0.
+
+### Returns
+
+Returns the timestamp for that date.
+
+
+### Examples
+
+```javascript
+SimpleCalendar.api.dateToTimestamp({}); //Returns the timestamp for the current date
+
+SimpleCalendar.api.dateToTimestamp({year: 2021, month: 0, day: 0, hour: 1, minute: 1, second: 0}); //Returns 1609462860
+```
+
+## `SimpleCalendar.api.isPrimaryGM()`
+
+Returns if the current user is considered the primary GM or not.
+
+### Examples
+
+```javascript
+
+SimpleCalendar.api.isPrimaryGM(); //True or Flase depending on if the current user is primary gm
+
+```
+
+
 ## `SimpleCalendar.api.secondsToInterval(seconds)`
 
 Will attempt to parse the passed in seconds into larger time intervals that make it up.
@@ -164,7 +200,7 @@ Will set the current date to the passed in date.
 
 Parameter|Type|Default Value|Description
 ---------|-----|-------------|-----------
-date|object or null|null|A date object (eg `{year:2021, month: 4, day: 12, hour: 0, mintue: 0, second: 0}`) with the parameters set to the date that the calendar should be set to. Any missing parameters will default to 0.<br>**Important**: The month and day are index based so January would be 0 and the first day of the month will also be 0.
+date|object or null|null|A date object (eg `{year:2021, month: 4, day: 12, hour: 0, mintue: 0, second: 0}`) with the parameters set to the date that the calendar should be set to. Any missing parameters will default to the current date value for that parameter.<br>**Important**: The month and day are index based so January would be 0 and the first day of the month will also be 0.
 
 ### Returns
 
@@ -180,7 +216,7 @@ SimpleCalendar.setDateTime(1999, 11, 24);
 SimpleCalendar.setDateTime(1999, 11, 30, 23, 59, 59);
 ```
 
-## `SimpleCalendar.api.showCalendar(date)`
+## `SimpleCalendar.api.showCalendar(date, compact)`
 
 Will open up Simple Calendar to the current date, or the passed in date.
 
@@ -189,12 +225,14 @@ Will open up Simple Calendar to the current date, or the passed in date.
 Parameter|Type|Default Value|Description
 ---------|-----|-------------|-----------
 date|object or null|null|A date object (eg `{year:2021, month: 4, day: 12}`) with the year, month and day set to the date to be visible when the calendar is opened.<br>**Important**: The month is index based so January would be 0.
+compact|boolean|false|If to open the calendar in compact mode or not.
 
 ### Examples
 ```javascript
 //Assuming a Gregorian Calendar
 SimpleCalendar.api.showCalendar(); // Will open the calendar to the current date.
 SimpleCalendar.api.showCalendar({year: 1999, month: 11, day: 25}); // Will open the calendar to the date December 25th, 1999
+SimpleCalendar.api.showCalendar(null, true); // Will opent the calendar to the current date in compact mode.
 ```
 
 ## `SimpleCalendar.api.timestamp()`
@@ -207,6 +245,33 @@ const timestamp = SimpleCalendar.api.timestamp();
 console.log(timestamp); // This will be a number representing the current number of seconds passed in the calendar.
 ```
 
+## `SimpleCalendar.api.startClock()`
+
+Starts the real time clock of Simple Calendar. Only the primary GM can start a clock.
+
+### Returns
+
+Will return true if the clock started, false if it did not.
+
+### Examples
+
+```javascript
+SimpleCalendar.api.startClock();
+```
+
+## `SimpleCalendar.api.stopClock()`
+
+Stops the real time clock of Simple Calendar.
+
+### Returns
+
+Will return true if the clock stopped, false if it did not.
+
+### Examples
+
+```javascript
+SimpleCalendar.api.stopClock();
+```
 
 ## `SimpleCalendar.api.timestampPlusInterval(timestamp, interval)`
 

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -209,3 +209,40 @@ This is an example of the data that is passed with this hook:
   "paused": false
 }
 ```
+
+
+## Is Primary GM
+
+### When it is emitted
+
+This eventn is emitted when the current users is promoted to the primary GM role. 
+
+This will happen 5 seconds after loading the game if no other GM is currently in the primary role.
+
+### What is passed
+
+Property Name|Value Type|Description
+-------------|-------------|------------
+isPrimaryGM|boolean|If the user is the primary gm (true).
+
+### Examples
+
+#### Hooking to
+
+This is an example of how to listen for the hook:
+
+```javascript
+Hooks.on(SimpleCalendar.Hooks.PrimaryGM, (data) => {
+    console.log(data);
+});
+```
+
+#### Response Data
+
+This is an example of the data that is passed with this hook:
+
+```json
+{
+  "isPrimaryGM": true
+}
+```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "foundryvtt-simple-calendar",
   "description": "A simple calendar module for keeping track of game days and events.",
-  "version": "1.2.73",
+  "version": "1.2.85",
   "author": "Dean Vigoren (vigorator)",
   "keywords": [
     "foundryvtt",

--- a/src/classes/api.test.ts
+++ b/src/classes/api.test.ts
@@ -15,9 +15,8 @@ import Year from "./year";
 import API from "./api";
 import Month from "./month";
 import {Weekday} from "./weekday";
-import {LeapYearRules} from "../constants";
+import {GameSystems, LeapYearRules} from "../constants";
 import SpyInstance = jest.SpyInstance;
-import Macros from "./macros";
 
 
 describe('API Class Tests', () => {
@@ -60,6 +59,12 @@ describe('API Class Tests', () => {
         expect(API.timestampPlusInterval(1623077754, {day: 1})).toBe(1623164154);
 
         expect(API.timestampPlusInterval(0, {second: 86401})).toBe(86401);
+
+        year.gameSystem = GameSystems.PF2E;
+        year.generalSettings.pf2eSync = true;
+        expect(API.timestampPlusInterval(0, {day: 0})).toBe(0);
+        expect(API.timestampPlusInterval(0, {})).toBe(0);
+        expect(API.timestampPlusInterval(0, {day: 1})).toBe(86400);
     });
 
     test('Timestamp to Date', () => {
@@ -69,6 +74,25 @@ describe('API Class Tests', () => {
         expect(API.timestampToDate(3600)).toStrictEqual({year: 0, month: 0, day: 0, dayOfTheWeek: 0, hour: 1, minute: 0, second: 0, monthName: "M1", yearName: "", yearZero: 0, weekdays: ["W1"]});
         expect(API.timestampToDate(5184000)).toStrictEqual({year: 1, month: 0, day: 0, dayOfTheWeek: 0, hour: 0, minute: 0, second: 0, monthName: "M1", yearName: "", yearZero: 0, weekdays: ["W1"]});
         expect(API.timestampToDate(5270400)).toStrictEqual({year: 1, month: 0, day: 1, dayOfTheWeek: 0, hour: 0, minute: 0, second: 0, monthName: "M1", yearName: "", yearZero: 0, weekdays: ["W1"]});
+
+        year.gameSystem = GameSystems.PF2E;
+        year.generalSettings.pf2eSync = true;
+        expect(API.timestampToDate(3600)).toStrictEqual({year: 0, month: 0, day: 0, dayOfTheWeek: 0, hour: 1, minute: 0, second: 0, monthName: "M1", yearName: "", yearZero: 0, weekdays: ["W1"]});
+        expect(API.timestampToDate(5184000)).toStrictEqual({year: 1, month: 0, day: 0, dayOfTheWeek: 0, hour: 0, minute: 0, second: 0, monthName: "M1", yearName: "", yearZero: 0, weekdays: ["W1"]});
+        expect(API.timestampToDate(5270400)).toStrictEqual({year: 1, month: 0, day: 1, dayOfTheWeek: 0, hour: 0, minute: 0, second: 0, monthName: "M1", yearName: "", yearZero: 0, weekdays: ["W1"]});
+    });
+
+    test('Date to Timestamp', () => {
+        expect(API.dateToTimestamp({})).toBe(0);
+        SimpleCalendar.instance.currentYear = year;
+
+        expect(API.dateToTimestamp({})).toBe(API.timestamp());
+        expect(API.dateToTimestamp({year: 2021, month: 5, day: 10, hour: 15, minute: 54, second: 29})).toBe(10480463669);
+
+        year.months[0].days[0].current = false;
+        expect(API.dateToTimestamp({year: 2021, hour: 15, minute: 54, second: 29})).toBe(10477007669);
+        year.months[0].current = false;
+        expect(API.dateToTimestamp({year: 2021, hour: 15, minute: 54, second: 29})).toBe(10477007669);
     });
 
     test('Seconds To Interval', () => {
@@ -83,7 +107,7 @@ describe('API Class Tests', () => {
         expect(API.clockStatus()).toStrictEqual({ started: false, stopped: true, paused: false });
     });
 
-    test('Show Clock', () => {
+    test('Show Calendar', () => {
         API.showCalendar();
         expect(renderSpy).toHaveBeenCalledTimes(0);
 
@@ -154,15 +178,15 @@ describe('API Class Tests', () => {
         expect(year.numericRepresentation).toBe(2021);
 
         API.setDate({month: 1, day: 1, hour: 1, minute: 1, second: 1});
-        expect(year.numericRepresentation).toBe(0);
-        expect(year.getMonth()?.numericRepresentation).toBe(2);
-        expect(year.getMonth()?.getDay()?.numericRepresentation).toBe(2);
+        expect(year.numericRepresentation).toBe(2021);
+        expect(year.months[1].current).toBe(true);
+        expect(year.months[1].days[2].current).toBe(true); //This doesn't fail in the browser, day should be 1
         expect(year.time.seconds).toBe(3661);
 
         year.yearZero = 1;
         API.setDate({month: -1, day: -1});
-        expect(year.getMonth()?.numericRepresentation).toBe(1);
-        expect(year.getMonth()?.getDay()?.numericRepresentation).toBe(1);
+        expect(year.getMonth()?.numericRepresentation).toBe(2);
+        expect(year.getMonth()?.getDay()?.numericRepresentation).toBe(30);
 
         //@ts-ignore
         game.user.isGM = false;
@@ -177,6 +201,26 @@ describe('API Class Tests', () => {
         expect(API.chooseRandomDate({year: 2000, month: 1, day: 0, hour: 0, minute: 0, second: 0},{year: 2021, month: 2, day: 1, hour: 12, minute:20, second:30})).toBeDefined();
         expect(API.chooseRandomDate({year: 2000, month: 1, day: 3, hour: 0, minute: 0, second: 0},{year: 2000, month: 1, day: 3, hour: 0, minute: 0, second: 0})).toStrictEqual({year: 2000, month: 1, day: 3, hour: 0, minute: 0, second: 0});
         expect(API.chooseRandomDate({year: 2000, month: -1, day: -3, hour: 0, minute: 0, second: 0},{year: 2000, month: -1, day: -3, hour: 0, minute: 0, second: 0})).toStrictEqual({year: 2000, month: 1, day: 30, hour: 0, minute: 0, second: 0});
+    });
+
+    test('Is Primary GM', () => {
+        expect(API.isPrimaryGM()).toBe(false);
+        // @ts-ignore
+        SimpleCalendar.instance = null;
+        expect(API.isPrimaryGM()).toBe(false);
+    });
+
+    test('Start Clock', () => {
+        expect(API.startClock()).toBe(false);
+        SimpleCalendar.instance.currentYear = year;
+        SimpleCalendar.instance.primary = true;
+        expect(API.startClock()).toBe(true);
+    });
+
+    test('Stop Clock', () => {
+        expect(API.stopClock()).toBe(false);
+        SimpleCalendar.instance.currentYear = year;
+        expect(API.stopClock()).toBe(true);
     });
 
 });

--- a/src/classes/hook.test.ts
+++ b/src/classes/hook.test.ts
@@ -63,9 +63,13 @@ describe('Hook Tests', () => {
         expect(console.error).toHaveBeenCalledTimes(2);
         expect(Hooks.callAll).toHaveBeenCalledTimes(4);
 
+        Hook.emit(SimpleCalendarHooks.PrimaryGM);
+        expect(console.error).toHaveBeenCalledTimes(2);
+        expect(Hooks.callAll).toHaveBeenCalledTimes(5);
+
         //@ts-ignore
         Hook.emit('asd');
         expect(console.error).toHaveBeenCalledTimes(2);
-        expect(Hooks.callAll).toHaveBeenCalledTimes(5);
+        expect(Hooks.callAll).toHaveBeenCalledTimes(6);
     });
 });

--- a/src/classes/hook.ts
+++ b/src/classes/hook.ts
@@ -1,4 +1,4 @@
-import {SimpleCalendarHooks} from "../constants";
+import {SimpleCalendarHooks, TimeKeeperStatus} from "../constants";
 import SimpleCalendar from "./simple-calendar";
 import {Logger} from "./logging";
 
@@ -54,10 +54,12 @@ export default class Hook{
                     });
                 }
             } else if(hook === SimpleCalendarHooks.ClockStartStop){
-                const status = SimpleCalendar.instance.currentYear.time.getClockClass();
-                data['started'] = status === 'started';
-                data['stopped'] = status === 'stopped';
-                data['paused'] = status === 'paused';
+                const status = SimpleCalendar.instance.currentYear.time.timeKeeper.getStatus();
+                data['started'] = status === TimeKeeperStatus.Started;
+                data['stopped'] = status === TimeKeeperStatus.Stopped;
+                data['paused'] = status === TimeKeeperStatus.Paused;
+            } else if(hook === SimpleCalendarHooks.PrimaryGM){
+                data['isPrimaryGM'] = SimpleCalendar.instance.primary;
             }
             Hooks.callAll(hook, data);
         } else {

--- a/src/classes/macros.ts
+++ b/src/classes/macros.ts
@@ -1,6 +1,4 @@
 import {Logger} from "./logging";
-import SimpleCalendar from "./simple-calendar";
-import {GameSettings} from "./game-settings";
 import API from "./api";
 
 export default class Macros {

--- a/src/classes/simple-calendar.test.ts
+++ b/src/classes/simple-calendar.test.ts
@@ -15,7 +15,7 @@ import SimpleCalendar from "./simple-calendar";
 import Year from "./year";
 import Month from "./month";
 import {Note} from "./note";
-import {GameWorldTimeIntegrations, SettingNames, SocketTypes} from "../constants";
+import {GameWorldTimeIntegrations, SettingNames, SocketTypes, TimeKeeperStatus} from "../constants";
 import {SimpleCalendarSocket} from "../interfaces";
 import {SimpleCalendarConfiguration} from "./simple-calendar-configuration";
 import {Weekday} from "./weekday";
@@ -109,7 +109,7 @@ describe('Simple Calendar Class Tests', () => {
         SimpleCalendar.instance.initializeSockets();
         // @ts-ignore
         expect(SimpleCalendar.instance.primaryCheckTimeout).toBeDefined();
-        expect(game.socket.emit).toHaveBeenCalledTimes(2);
+        expect(game.socket.emit).toHaveBeenCalledTimes(1);
         // @ts-ignore
         game.user.isGM = false;
     });
@@ -117,36 +117,51 @@ describe('Simple Calendar Class Tests', () => {
     test('Primary Check Timeout Call', () => {
         SimpleCalendar.instance.primaryCheckTimeoutCall();
         expect(SimpleCalendar.instance.primary).toBe(true);
-        expect(game.socket.emit).toHaveBeenCalledTimes(1);
+        expect(game.socket.emit).toHaveBeenCalledTimes(2);
     })
 
     test('Process Socket', async () => {
         const d: SimpleCalendarSocket.Data = {
             type: SocketTypes.time,
             data: {
-                clockClass: ''
+                timeKeeperStatus: TimeKeeperStatus.Stopped
             }
         };
         await SimpleCalendar.instance.processSocket(d);
-        expect(renderSpy).toHaveBeenCalledTimes(1);
+        expect(renderSpy).toHaveBeenCalledTimes(0);
+
+        SimpleCalendar.instance.currentYear = y;
+        const orig = SimpleCalendar.instance.element;
+        //@ts-ignore
+        SimpleCalendar.instance.element = {
+            find: jest.fn().mockReturnValue({
+                removeClass: jest.fn().mockReturnValue({addClass: jest.fn()}),
+                text: jest.fn()
+            })
+        }
+        await SimpleCalendar.instance.processSocket(d);
+        expect(renderSpy).toHaveBeenCalledTimes(0);
+        //@ts-ignore
+        SimpleCalendar.instance.element = orig;
+        SimpleCalendar.instance.currentYear = null;
 
         d.type = SocketTypes.journal;
         d.data = {notes: []};
         await SimpleCalendar.instance.processSocket(d);
-        expect(renderSpy).toHaveBeenCalledTimes(1);
+        expect(renderSpy).toHaveBeenCalledTimes(0);
 
         // @ts-ignore
         game.user.isGM = true;
         SimpleCalendar.instance.primary = true;
         await SimpleCalendar.instance.processSocket(d);
-        expect(renderSpy).toHaveBeenCalledTimes(1);
+        expect(renderSpy).toHaveBeenCalledTimes(0);
 
         d.type = SocketTypes.primary;
         d.data = {
             primaryCheck: true
         };
         await SimpleCalendar.instance.processSocket(d);
-        expect(renderSpy).toHaveBeenCalledTimes(1);
+        expect(renderSpy).toHaveBeenCalledTimes(0);
         expect(game.socket.emit).toHaveBeenCalledTimes(1);
         d.data = {
             amPrimary: true
@@ -236,7 +251,7 @@ describe('Simple Calendar Class Tests', () => {
         //@ts-ignore
         d.type = 'asd';
         await SimpleCalendar.instance.processSocket(d);
-        expect(renderSpy).toHaveBeenCalledTimes(1);
+        expect(renderSpy).toHaveBeenCalledTimes(0);
     });
 
     test('Get Data', async () => {
@@ -1252,6 +1267,7 @@ describe('Simple Calendar Class Tests', () => {
                 default:
                     return null;
             }};
+        //@ts-ignore
         SimpleCalendar.instance.settingUpdate();
         expect(SimpleCalendar.instance.currentYear?.numericRepresentation).toBe(0);
         expect(SimpleCalendar.instance.currentYear?.months[0].current).toBe(true);
@@ -1337,25 +1353,27 @@ describe('Simple Calendar Class Tests', () => {
         expect(y.time.combatRunning).toBe(false);
     });
 
-    test('Game Paused', () => {
-        SimpleCalendar.instance.gamePaused(false);
-        SimpleCalendar.instance.currentYear = y;
-        SimpleCalendar.instance.gamePaused(false);
-    });
-
     test('Start Time', () => {
+
+        const orig = SimpleCalendar.instance.element.find;
+
+        SimpleCalendar.instance.element.find = jest.fn().mockReturnValue({
+            removeClass: jest.fn().mockReturnValue({
+                addClass: jest.fn()
+            })
+        });
+
         SimpleCalendar.instance.startTime();
         SimpleCalendar.instance.currentYear = y;
         SimpleCalendar.instance.startTime();
-        expect(y.time.keeper).toBeUndefined();
+        expect(y.time.timeKeeper.getStatus()).toBe(TimeKeeperStatus.Stopped);
         y.generalSettings.gameWorldTimeIntegration = GameWorldTimeIntegrations.Self;
         SimpleCalendar.instance.startTime();
-        expect(y.time.keeper).toBeDefined();
+        expect(y.time.timeKeeper.getStatus()).toBe(TimeKeeperStatus.Paused);
         //@ts-ignore
         game.combats.size = 1;
         SimpleCalendar.instance.startTime();
 
-        y.time.keeper = undefined;
         //@ts-ignore
         game.scenes = {active: {id: '123'}};
         //@ts-ignore
@@ -1364,16 +1382,18 @@ describe('Simple Calendar Class Tests', () => {
             return v.call(undefined, {started: true, scene: {id: "123"}});
         });
         SimpleCalendar.instance.startTime();
-        expect(y.time.keeper).toBeUndefined();
+        expect(y.time.timeKeeper.getStatus()).toBe(TimeKeeperStatus.Paused);
+
+        SimpleCalendar.instance.element.find = orig;
     });
 
     test('Stop Time', () => {
-        y.time.keeper = 1;
+        //y.time.keeper = 1;
         SimpleCalendar.instance.stopTime();
-        expect(y.time.keeper).toBe(1);
+        //expect(y.time.keeper).toBe(1);
         SimpleCalendar.instance.currentYear = y;
         SimpleCalendar.instance.stopTime();
-        expect(y.time.keeper).toBeUndefined();
+        expect(y.time.timeKeeper.getStatus()).toBe(TimeKeeperStatus.Stopped);
     });
 
     test('Time Keeping Check', async () => {

--- a/src/classes/simple-calendar.ts
+++ b/src/classes/simple-calendar.ts
@@ -8,7 +8,12 @@ import {GameSettings} from "./game-settings";
 import {Weekday} from "./weekday";
 import {SimpleCalendarNotes} from "./simple-calendar-notes";
 import HandlebarsHelpers from "./handlebars-helpers";
-import {GameWorldTimeIntegrations, ModuleSocketName, SimpleCalendarHooks, SocketTypes} from "../constants";
+import {
+    GameWorldTimeIntegrations,
+    ModuleSocketName, SimpleCalendarHooks,
+    SocketTypes,
+    TimeKeeperStatus
+} from "../constants";
 import Importer from "./importer";
 import Season from "./season";
 import Moon from "./moon";
@@ -110,9 +115,6 @@ export default class SimpleCalendar extends Application{
     public initializeSockets(){
         //Set up the socket we use to forward data between players and the GM
         game.socket.on(ModuleSocketName, this.processSocket.bind(this));
-        if(this.currentYear){
-            this.currentYear.time.updateUsers();
-        }
 
         if(GameSettings.IsGm()){
             const socket = <SimpleCalendarSocket.Data>{
@@ -134,8 +136,11 @@ export default class SimpleCalendar extends Application{
         this.primary = true;
         const socketData = <SimpleCalendarSocket.Data>{type: SocketTypes.primary, data: {amPrimary: this.primary}};
         game.socket.emit(ModuleSocketName, socketData);
+        const timeKeeperSocketData = <SimpleCalendarSocket.Data>{type: SocketTypes.time, data: {timeKeeperStatus: TimeKeeperStatus.Stopped}}
+        game.socket.emit(ModuleSocketName, timeKeeperSocketData);
         await this.timeKeepingCheck();
         this.updateApp();
+        Hook.emit(SimpleCalendarHooks.PrimaryGM);
     }
 
     /**
@@ -146,8 +151,11 @@ export default class SimpleCalendar extends Application{
         Logger.debug(`Processing ${data.type} socket emit`);
         if(data.type === SocketTypes.time){
             // This is processed by all players to update the animated clock
-            this.clockClass = (<SimpleCalendarSocket.SimpleCalendarSocketTime>data.data).clockClass;
-            this.updateApp();
+            if(this.currentYear){
+                this.currentYear.time.timeKeeper.setStatus((<SimpleCalendarSocket.SimpleCalendarSocketTime>data.data).timeKeeperStatus);
+                this.clockClass = this.currentYear.time.timeKeeper.getStatus();
+                this.currentYear.time.timeKeeper.setClockTime(this.currentYear.time.toString());
+            }
         } else if (data.type === SocketTypes.journal){
             // If user is a GM and the primary GM then save the journal requests, otherwise do nothing
             if(GameSettings.IsGm() && this.primary){
@@ -313,6 +321,7 @@ export default class SimpleCalendar extends Application{
     public showApp(){
         if(this.currentYear && this.currentYear.canUser(game.user, this.currentYear.generalSettings.permissions.viewCalendar)){
             this.hasBeenResized = false;
+            this.currentYear.setCurrentToVisible();
             this.render(true, {});
         }
     }
@@ -1008,7 +1017,7 @@ export default class SimpleCalendar extends Application{
             this.loadGeneralSettings();
         }
         this.loadCurrentDate();
-        if(update) {
+        if(update && this.currentYear?.time.timeKeeper.getStatus() !== TimeKeeperStatus.Started) {
             this.updateApp();
         }
     }
@@ -1246,8 +1255,8 @@ export default class SimpleCalendar extends Application{
         const currentDate = GameSettings.LoadCurrentDate();
         if(this.currentYear && currentDate && Object.keys(currentDate).length){
             this.currentYear.numericRepresentation = currentDate.year;
-            this.currentYear.visibleYear = currentDate.year;
             this.currentYear.selectedYear = currentDate.year;
+            this.currentYear.visibleYear = currentDate.year;
 
             this.currentYear.resetMonths('current');
             this.currentYear.resetMonths('visible');
@@ -1347,8 +1356,6 @@ export default class SimpleCalendar extends Application{
         const activeScene = game.scenes? game.scenes.active.id : null;
         if(this.currentYear && combat.started && ((activeScene !== null && combat.scene && combat.scene.id === activeScene) || activeScene === null)){
             this.currentYear.time.combatRunning = true;
-            this.currentYear.time.updateUsers();
-            Hook.emit(SimpleCalendarHooks.ClockStartStop);
             if(time && time.hasOwnProperty('advanceTime')){
                 Logger.debug('Combat Change Triggered');
                 this.currentYear.combatChangeTriggered = true;
@@ -1363,19 +1370,6 @@ export default class SimpleCalendar extends Application{
         Logger.debug('Combat Ended');
         if(this.currentYear){
             this.currentYear.time.combatRunning = false;
-            this.currentYear.time.updateUsers();
-            Hook.emit(SimpleCalendarHooks.ClockStartStop);
-        }
-    }
-
-    /**
-     * Triggered when the game is paused/un-paused
-     * @param {boolean} paused If the game is now paused or not
-     */
-    gamePaused(paused: boolean){
-        if(this.currentYear){
-            this.currentYear.time.updateUsers();
-            Hook.emit(SimpleCalendarHooks.ClockStartStop);
         }
     }
 
@@ -1388,7 +1382,7 @@ export default class SimpleCalendar extends Application{
             if(game.combats && game.combats.size > 0 && game.combats.find(g => g.started && ((activeScene !== null && g.scene && g.scene.id === activeScene) || activeScene === null))){
                 GameSettings.UiNotification(game.i18n.localize('FSC.Warn.Time.ActiveCombats'), 'warn');
             } else if(this.currentYear.generalSettings.gameWorldTimeIntegration === GameWorldTimeIntegrations.Self || this.currentYear.generalSettings.gameWorldTimeIntegration === GameWorldTimeIntegrations.Mixed){
-                this.currentYear.time.startTimeKeeper();
+                this.currentYear.time.timeKeeper.start();
             }
         }
     }
@@ -1398,7 +1392,7 @@ export default class SimpleCalendar extends Application{
      */
     stopTime(){
         if(this.currentYear){
-            this.currentYear.time.stopTimeKeeper();
+            this.currentYear.time.timeKeeper.stop();
         }
     }
 

--- a/src/classes/systems/pf2e.test.ts
+++ b/src/classes/systems/pf2e.test.ts
@@ -1,0 +1,33 @@
+import "../../../__mocks__/game";
+import PF2E from "./pf2e";
+
+describe('Systems/PF2E Class Tests', () => {
+
+    test('Get World Create Seconds', () => {
+        expect(PF2E.getWorldCreateSeconds()).toBe(0);
+
+        //@ts-ignore
+        game.pf2e = {worldClock: {dateTheme: "AD", worldCreatedOn: 10000}};
+        expect(PF2E.getWorldCreateSeconds()).toBe(10);
+
+        //@ts-ignore
+        game.pf2e = {worldClock: {dateTheme: "AR", worldCreatedOn: 10000}};
+        expect(PF2E.getWorldCreateSeconds()).toBe(62167219210);
+
+    });
+
+    test('New Year Zero', () => {
+        //@ts-ignore
+        delete game.pf2e;
+        expect(PF2E.newYearZero()).toBeUndefined();
+
+        //@ts-ignore
+        game.pf2e = {worldClock: {dateTheme: "AR", worldCreatedOn: 10000}};
+        expect(PF2E.newYearZero()).toBeUndefined();
+
+        //@ts-ignore
+        game.pf2e = {worldClock: {dateTheme: "AD", worldCreatedOn: 10000}};
+        expect(PF2E.newYearZero()).toBe(1875);
+
+    });
+});

--- a/src/classes/systems/pf2e.ts
+++ b/src/classes/systems/pf2e.ts
@@ -1,0 +1,41 @@
+/**
+ * System specific functionality for Pathfinder 2E
+ */
+export default class PF2E {
+    /**
+     * Gets the world creation time in seconds
+     * @return {number}
+     */
+    public static getWorldCreateSeconds(): number{
+        let seconds = 0;
+        // If this is a Pathfinder 2E game, when setting Simple Calendar from the world time we need to add:
+        //  - The World Create Time Stamp Offset (Used by PF2E to calculate the current world time) - This is a timestamp in Real world time
+        //  - The offset from year 0 to Jan 1 1970 (This is because the World Create Time Stamp is based on a timestamp from 1970 so need to make up that difference)
+        if(game.hasOwnProperty('pf2e')){
+            // @ts-ignore
+            let worldCreateTimeStamp = Math.floor(game.pf2e.worldClock.worldCreatedOn/1000);
+            // @ts-ignore
+            if(game.pf2e.worldClock.dateTheme === 'AR' || game.pf2e.worldClock.dateTheme === 'IC') {
+                worldCreateTimeStamp += 62167219200;
+            }
+            seconds += worldCreateTimeStamp;
+        }
+        return seconds;
+    }
+
+    /**
+     * Determines if we need to set a new year zero for the pathfinder 2e calendar
+     * @return {number|undefined} If no adjustment, undefined otherwise the new year zero is returned
+     */
+    public static newYearZero(): number | undefined{
+        let yearZero;
+        if(game.hasOwnProperty('pf2e')){
+            //If we are using the Gregorian Calendar that ties into the pathfinder world we need to set the year zero to 1875
+            // @ts-ignore
+            if(game.pf2e.worldClock.dateTheme === 'AD'){
+                yearZero = 1875;
+            }
+        }
+        return yearZero;
+    }
+}

--- a/src/classes/time-keeper.test.ts
+++ b/src/classes/time-keeper.test.ts
@@ -1,0 +1,167 @@
+/**
+ * @jest-environment jsdom
+ */
+import "../../__mocks__/game";
+import "../../__mocks__/form-application";
+import "../../__mocks__/application";
+import "../../__mocks__/handlebars";
+import "../../__mocks__/event";
+import "../../__mocks__/crypto";
+import "../../__mocks__/dialog";
+import "../../__mocks__/hooks";
+
+import TimeKeeper from "./time-keeper";
+import SimpleCalendar from "./simple-calendar";
+import {TimeKeeperStatus} from "../constants";
+import Year from "./year";
+
+describe('Time Keeper Class Tests', () => {
+    let tk: TimeKeeper
+
+    beforeEach(() => {
+        tk = new TimeKeeper();
+        SimpleCalendar.instance = new SimpleCalendar();
+    });
+
+
+    test('Start/Stop', () => {
+        tk.start();
+        //@ts-ignore
+        expect(tk.intervalNumber).toBeDefined();
+        //@ts-ignore
+        expect(tk.saveIntervalNumber).toBeUndefined();
+
+
+        tk.start();
+        //@ts-ignore
+        expect(tk.intervalNumber).toBeDefined();
+        //@ts-ignore
+        expect(tk.saveIntervalNumber).toBeUndefined();
+
+        tk.stop();
+        //@ts-ignore
+        expect(tk.intervalNumber).toBeUndefined();
+        //@ts-ignore
+        expect(tk.saveIntervalNumber).toBeUndefined();
+
+        tk.stop();
+        //@ts-ignore
+        expect(tk.intervalNumber).toBeUndefined();
+        //@ts-ignore
+        expect(tk.saveIntervalNumber).toBeUndefined();
+
+        //@ts-ignore
+        game.user.isGM = true;
+        SimpleCalendar.instance.primary = true;
+
+        tk.start();
+        //@ts-ignore
+        expect(tk.intervalNumber).toBeDefined();
+        //@ts-ignore
+        expect(tk.saveIntervalNumber).toBeDefined();
+
+        tk.stop();
+        //@ts-ignore
+        expect(tk.intervalNumber).toBeUndefined();
+        //@ts-ignore
+        expect(tk.saveIntervalNumber).toBeUndefined();
+    });
+
+    test('Get Status', () => {
+        expect(tk.getStatus()).toBe(TimeKeeperStatus.Stopped);
+    });
+
+    test('Set Status', () => {
+        const o = SimpleCalendar.instance.element;
+        //@ts-ignore
+        SimpleCalendar.instance.element = {
+            find: jest.fn().mockReturnValue({
+                removeClass: jest.fn().mockReturnValue({addClass: jest.fn()})
+            })
+        };
+
+        tk.setStatus(TimeKeeperStatus.Paused);
+        expect(tk.getStatus()).toBe(TimeKeeperStatus.Paused);
+
+        //@ts-ignore
+        SimpleCalendar.instance.element = o;
+    });
+
+    test('Set Clock Time', () => {
+        const o = SimpleCalendar.instance.element;
+        //@ts-ignore
+        SimpleCalendar.instance.element = {
+            find: jest.fn().mockReturnValue({
+                removeClass: jest.fn().mockReturnValue({addClass: jest.fn()}),
+                text: jest.fn()
+            })
+        };
+
+        tk.setClockTime('');
+        //@ts-ignore
+        expect(SimpleCalendar.instance.element.find).not.toHaveBeenCalled();
+        SimpleCalendar.instance.currentYear = new Year(0);
+        tk.setClockTime('');
+        //@ts-ignore
+        expect(SimpleCalendar.instance.element.find).toHaveBeenCalled();
+
+        //@ts-ignore
+        SimpleCalendar.instance.element = o;
+    });
+
+    test('Interval', () => {
+        const o = SimpleCalendar.instance.element;
+        //@ts-ignore
+        SimpleCalendar.instance.element = {
+            find: jest.fn().mockReturnValue({
+                removeClass: jest.fn().mockReturnValue({addClass: jest.fn()}),
+                text: jest.fn()
+            })
+        };
+
+        //@ts-ignore
+        tk.interval();
+
+        SimpleCalendar.instance.currentYear = new Year(0);
+        //@ts-ignore
+        tk.interval();
+
+        //@ts-ignore
+        game.paused = false;
+        tk.start();
+        //@ts-ignore
+        tk.interval();
+
+        SimpleCalendar.instance.currentYear.time.seconds = SimpleCalendar.instance.currentYear.time.secondsPerDay - 1;
+        //@ts-ignore
+        tk.interval();
+
+        //@ts-ignore
+        game.user.isGM = true;
+        SimpleCalendar.instance.primary = true;
+
+        //@ts-ignore
+        tk.interval();
+
+
+        tk.stop();
+        //@ts-ignore
+        SimpleCalendar.instance.element = o;
+    });
+
+    test('Save Interval', () => {
+        //@ts-ignore
+        tk.saveInterval();
+
+        SimpleCalendar.instance.currentYear = new Year(0);
+
+        //@ts-ignore
+        tk.saveInterval();
+        //@ts-ignore
+        game.user.isGM = true;
+        SimpleCalendar.instance.primary = true;
+
+        //@ts-ignore
+        tk.saveInterval();
+    });
+});

--- a/src/classes/time-keeper.ts
+++ b/src/classes/time-keeper.ts
@@ -1,0 +1,162 @@
+import {Logger} from "./logging";
+import {ModuleSocketName, SimpleCalendarHooks, SocketTypes, TimeKeeperStatus} from "../constants";
+import SimpleCalendar from "./simple-calendar";
+import Hook from "./hook";
+import {GameSettings} from "./game-settings";
+import {SimpleCalendarSocket} from "../interfaces";
+
+/**
+ * The Time Keeper class used by the built in Simple Calendar Clock to keep real time
+ */
+export default class TimeKeeper{
+    /**
+     * The interval that is run every second to update the clock
+     * @type {number | undefined}
+     * @private
+     */
+    private intervalNumber: number | undefined;
+    /**
+     * The interval that us run every 10 seconds to save the current time and force sync across all players
+     * @type {number | undefined}
+     * @private
+     */
+    private saveIntervalNumber: number | undefined;
+    /**
+     * The current status of the time keeper
+     * @type {TimeKeeperStatus}
+     * @private
+     */
+    private status: TimeKeeperStatus = TimeKeeperStatus.Stopped;
+
+    constructor() {
+    }
+
+    /**
+     * Starts the time keeper interval and save interval
+     */
+    public start(){
+        if(this.intervalNumber === undefined){
+            Logger.debug(`TimeKeeper Starting`);
+            this.intervalNumber = window.setInterval(this.interval.bind(this), 1000);
+            this.updateStatus();
+            if(GameSettings.IsGm() && SimpleCalendar.instance.primary){
+                this.saveInterval();
+                this.saveIntervalNumber = window.setInterval(this.saveInterval.bind(this), 10000);
+            }
+        }
+    }
+
+    /**
+     * Stops the time keeper interval and save interval
+     */
+    public stop(){
+        if(this.intervalNumber !== undefined){
+            Logger.debug(`TimeKeeper Stopping`);
+            window.clearInterval(this.intervalNumber);
+            window.clearInterval(this.saveIntervalNumber);
+            this.intervalNumber = undefined;
+            this.saveIntervalNumber = undefined;
+            this.updateStatus();
+            if(GameSettings.IsGm() && SimpleCalendar.instance.primary){
+                this.saveInterval();
+            }
+        }
+    }
+
+    /**
+     * Returns the current status of the time keeper
+     */
+    public getStatus(){
+        return this.status;
+    }
+
+    /**
+     * Sets a new status for the time keeper and updates the clock display
+     * @param {TimeKeeperStatus} newStatus
+     */
+    public setStatus(newStatus: TimeKeeperStatus){
+        this.status = newStatus;
+        SimpleCalendar.instance.element.find('.time-display .clock, .time-controls .time-start, .time-controls .time-stop, .current-time .clock').removeClass('stopped started paused').addClass(this.status);
+    }
+
+    public setClockTime(time: string){
+        if(SimpleCalendar.instance && SimpleCalendar.instance.currentYear){
+            SimpleCalendar.instance.element.find('.time-display .time, .current-time .time').text(time);
+        }
+    }
+
+    /**
+     * The interval function that is called every second. Responsible for updating the clock display
+     * @private
+     */
+    private interval(){
+        this.updateStatus();
+        if(SimpleCalendar.instance && SimpleCalendar.instance.currentYear){
+            if(this.status === TimeKeeperStatus.Started){
+                const dayChange = SimpleCalendar.instance.currentYear.time.changeTime(0, 0, SimpleCalendar.instance.currentYear.time.gameTimeRatio);
+                if(dayChange !== 0){
+                    SimpleCalendar.instance.currentYear.changeDay(dayChange);
+                    SimpleCalendar.instance.updateApp();
+                }
+                //SimpleCalendar.instance.element.find('.time-display .time, .current-time .time').text(SimpleCalendar.instance.currentYear.time.toString());
+                if (GameSettings.IsGm() && SimpleCalendar.instance.primary) {
+                    SimpleCalendar.instance.currentYear.syncTime().catch(Logger.error);
+                }
+            }
+        }
+    }
+
+    /**
+     * The save interval function that is called every 10 seconds to save the current time
+     * @private
+     */
+    private saveInterval(){
+        if(SimpleCalendar.instance && SimpleCalendar.instance.currentYear) {
+            if (GameSettings.IsGm() && SimpleCalendar.instance.primary) {
+                SimpleCalendar.instance.currentYear.syncTime().catch(Logger.error);
+                GameSettings.SaveCurrentDate(SimpleCalendar.instance.currentYear).catch(Logger.error);
+            }
+        }
+    }
+
+    /**
+     * Checks the current state of the world and updates the time keepers status accordingly.
+     * If the status has changed, emits the socket and hook calls to update all players, modules, systems and macros
+     * @private
+     */
+    private updateStatus(){
+        const oldStatus = this.status;
+        if(this.intervalNumber !== undefined){
+            if(game.paused || (SimpleCalendar.instance && SimpleCalendar.instance.currentYear && SimpleCalendar.instance.currentYear.time.combatRunning)){
+                this.status = TimeKeeperStatus.Paused;
+            } else {
+                this.status = TimeKeeperStatus.Started;
+            }
+        } else {
+            this.status = TimeKeeperStatus.Stopped;
+        }
+        //If the status has changed, emit that change
+        if(oldStatus !== this.status){
+            Logger.debug(`Updating Timer Status from ${oldStatus} to ${this.status}`);
+            Hook.emit(SimpleCalendarHooks.ClockStartStop);
+            this.emitSocket();
+        }
+    }
+
+    /**
+     * Creates the socket data package and emits on the socket to all connected players.
+     * @private
+     */
+    private emitSocket(){
+        if(GameSettings.IsGm() && SimpleCalendar.instance.primary){
+            const socketData = <SimpleCalendarSocket.Data>{
+                type: SocketTypes.time,
+                data: {
+                    timeKeeperStatus: this.status
+                }
+            };
+            game.socket.emit(ModuleSocketName, socketData);
+            SimpleCalendar.instance.processSocket(socketData).catch(Logger.error);
+        }
+    }
+}

--- a/src/classes/time.test.ts
+++ b/src/classes/time.test.ts
@@ -8,8 +8,6 @@ import "../../__mocks__/handlebars";
 import "../../__mocks__/event";
 import "../../__mocks__/hooks";
 import Time from "./time";
-import SimpleCalendar from "./simple-calendar";
-import Year from "./year";
 
 describe('Time Tests', () => {
     let t: Time;
@@ -19,14 +17,14 @@ describe('Time Tests', () => {
     });
 
     test('Properties', () => {
-        expect(Object.keys(t).length).toBe(7); //Make sure no new properties have been added
+        expect(Object.keys(t).length).toBe(8); //Make sure no new properties have been added
         expect(t.hoursInDay).toBe(24);
         expect(t.minutesInHour).toBe(60);
         expect(t.secondsInMinute).toBe(60);
         expect(t.gameTimeRatio).toBe(1);
         expect(t.seconds).toBe(0);
         expect(t.secondsPerDay).toBe(86400);
-        expect(t.keeper).toBeUndefined();
+        expect(t.timeKeeper).toBeDefined();
         expect(t.combatRunning).toBe(false);
     });
 
@@ -39,6 +37,10 @@ describe('Time Tests', () => {
         expect(t.getCurrentTime()).toStrictEqual({"hour": "00", "minute": "00", "second": "00"});
         t.seconds = t.secondsPerDay - 1;
         expect(t.getCurrentTime()).toStrictEqual({"hour": "23", "minute": "59", "second": "59"});
+    });
+
+    test('To String', () => {
+        expect(t.toString()).toBe('00:00:00');
     });
 
     test('Set Time', () => {
@@ -73,74 +75,8 @@ describe('Time Tests', () => {
         expect(t.getTotalSeconds(1)).toBe(86410);
     });
 
-    test('Get Clock Class', () => {
-        expect(t.getClockClass()).toBe('stopped');
-        t.keeper = 2;
-        expect(t.getClockClass()).toBe('paused');
-        //@ts-ignore
-        game.paused = false;
-        expect(t.getClockClass()).toBe('started');
-        t.combatRunning = true;
-        expect(t.getClockClass()).toBe('paused');
-    });
-
     test('Set World Time', () => {
         t.setWorldTime(100);
         expect(game.time.advance).toHaveBeenCalledTimes(1);
-    });
-
-    test('Start Time Keeper', () => {
-        SimpleCalendar.instance = new SimpleCalendar();
-        SimpleCalendar.instance.currentYear = new Year(0);
-        window.setInterval = jest.fn().mockReturnValue(2);
-        t.startTimeKeeper();
-        expect(window.setInterval).toHaveBeenCalledTimes(1);
-        t.startTimeKeeper();
-        expect(window.setInterval).toHaveBeenCalledTimes(1);
-    });
-
-    test('Stop Time Keeper', () => {
-        window.clearInterval = jest.fn();
-        t.stopTimeKeeper();
-        expect(window.clearInterval).not.toHaveBeenCalled();
-        t.keeper = 2;
-        t.stopTimeKeeper();
-        expect(window.clearInterval).toHaveBeenCalledTimes(1);
-        t.stopTimeKeeper();
-        expect(window.clearInterval).toHaveBeenCalledTimes(1);
-    });
-
-    test('Time Keeper', () => {
-        SimpleCalendar.instance = new SimpleCalendar();
-        //@ts-ignore
-        game.paused = true;
-        t.combatRunning = false;
-        t.timeKeeper();
-        //@ts-ignore
-        game.paused = false;
-        t.combatRunning = true;
-        t.timeKeeper();
-
-        t.combatRunning = false;
-        t.timeKeeper();
-
-        t.seconds = 86400;
-        t.timeKeeper();
-        expect(t.seconds).toBe(30);
-
-        SimpleCalendar.instance.currentYear = new Year(1);
-        t.timeKeeper();
-        t.seconds = 86400;
-        t.timeKeeper();
-        expect(t.seconds).toBe(30);
-    });
-
-    test('Update Users', () => {
-        t.updateUsers();
-        expect(game.socket.emit).not.toHaveBeenCalled();
-        //@ts-ignore
-        game.user.isGM = true;
-        t.updateUsers();
-        expect(game.socket.emit).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -130,5 +130,12 @@ export enum GameSystems {
 
 export enum SimpleCalendarHooks {
     DateTimeChange = 'simple-calendar-date-time-change',
-    ClockStartStop = 'simple-calendar-clock-start-stop'
+    ClockStartStop = 'simple-calendar-clock-start-stop',
+    PrimaryGM = 'simple-calendar-primary-gm'
+}
+
+export enum TimeKeeperStatus {
+    Started = 'started',
+    Stopped = 'stopped',
+    Paused = 'paused'
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,33 +7,22 @@ SimpleCalendar.instance = new SimpleCalendar();
 Hooks.on('init', () => {
     //Initialize the Simple Calendar
     SimpleCalendar.instance.init();
-});
-Hooks.on('ready', () => {
-    //Initialize the Simple Calendar Sockets
-    SimpleCalendar.instance.initializeSockets();
-    //Expose the macro show function
+    //Expose the api
     (window as any).SimpleCalendar = {
         show: Macros.show,
         setDateTime: Macros.setDateTime,
         changeDateTime: Macros.changeDateTime,
-        api:{
-            changeDate: API.changeDate,
-            chooseRandomDate: API.chooseRandomDate,
-            clockStatus: API.clockStatus,
-            secondsToInterval: API.secondsToInterval,
-            setDate: API.setDate,
-            showCalendar: API.showCalendar,
-            timestamp: API.timestamp,
-            timestampPlusInterval: API.timestampPlusInterval,
-            timestampToDate: API.timestampToDate
-        },
+        api:API,
         Hooks: SimpleCalendarHooks
     };
+});
+Hooks.on('ready', () => {
+    //Initialize the Simple Calendar Sockets
+    SimpleCalendar.instance.initializeSockets();
 });
 Hooks.on('getSceneControlButtons', SimpleCalendar.instance.getSceneControlButtons.bind(SimpleCalendar.instance));
 Hooks.on("updateWorldTime", SimpleCalendar.instance.worldTimeUpdate.bind(SimpleCalendar.instance));
 Hooks.on("updateCombat", SimpleCalendar.instance.combatUpdate.bind(SimpleCalendar.instance));
 Hooks.on("deleteCombat", SimpleCalendar.instance.combatDelete.bind(SimpleCalendar.instance));
-Hooks.on("pauseGame", SimpleCalendar.instance.gamePaused.bind(SimpleCalendar.instance));
 
 Logger.debugMode = false;

--- a/src/interfaces.test.ts
+++ b/src/interfaces.test.ts
@@ -21,7 +21,15 @@ import {
     YearConfig,
     YearTemplate
 } from "./interfaces";
-import {GameSystems, LeapYearRules, MoonIcons, MoonYearResetOptions, SocketTypes, YearNamingRules} from "./constants";
+import {
+    GameSystems,
+    LeapYearRules,
+    MoonIcons,
+    MoonYearResetOptions,
+    SocketTypes,
+    TimeKeeperStatus,
+    YearNamingRules
+} from "./constants";
 
 describe('Interface Tests', () => {
     const tt: TimeTemplate = {hour: '', minute: '', second: ''};
@@ -321,9 +329,9 @@ describe('Interface Tests', () => {
         });
 
         test('Simple Calendar Socket Time', () => {
-            const scst: SimpleCalendarSocket.SimpleCalendarSocketTime = {clockClass: ''};
+            const scst: SimpleCalendarSocket.SimpleCalendarSocketTime = {timeKeeperStatus: TimeKeeperStatus.Stopped};
             expect(Object.keys(scst).length).toBe(1); //Make sure no new properties have been added
-            expect(scst.clockClass).toBe('');
+            expect(scst.timeKeeperStatus).toBe(TimeKeeperStatus.Stopped);
         });
 
         test('Simple Calendar Socket Journal', () => {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -7,7 +7,7 @@ import {
     GameWorldTimeIntegrations,
     SocketTypes,
     MoonIcons,
-    MoonYearResetOptions, GameSystems, YearNamingRules
+    MoonYearResetOptions, GameSystems, YearNamingRules, TimeKeeperStatus
 } from "./constants";
 import {Note} from "./classes/note";
 
@@ -376,7 +376,7 @@ export namespace SimpleCalendarSocket{
      * Interface for socket data that has to do with the time
      */
     export interface SimpleCalendarSocketTime{
-        clockClass: string;
+        timeKeeperStatus: TimeKeeperStatus;
     }
 
     /**

--- a/src/module.json
+++ b/src/module.json
@@ -2,7 +2,7 @@
   "name": "foundryvtt-simple-calendar",
   "title": "Simple Calendar",
   "description": "A simple calendar module for keeping track of game days and events.",
-  "version": "1.2.73",
+  "version": "1.2.85",
   "author": "Dean Vigoren (Vigorator)",
   "authors": [
     {

--- a/src/styles/calendar.scss
+++ b/src/styles/calendar.scss
@@ -191,8 +191,13 @@
   flex-direction: row;
   justify-content: center;
 
+  .text{
+    margin-right: 6px;
+  }
+
 
 }
+
 .clock {
   position:relative;
   transform:scale(1.25);
@@ -224,7 +229,7 @@
     content:'';
     left: 8.25px;
     top: 3.75px;
-    animation-duration: 60s;
+    animation-duration: 10s;
   }
   &.stopped{
     border-color:#c12121;
@@ -403,7 +408,7 @@
         line-height: 22px;
         font-size: 0.75rem;
 
-        &.go{
+        &.started{
           color: green;
         }
         &.paused{

--- a/src/styles/gm-controls.scss
+++ b/src/styles/gm-controls.scss
@@ -72,7 +72,7 @@
         margin: 0 10px;
         line-height: 22px;
 
-        &.go{
+        &.started{
           color: green;
         }
         &.paused{

--- a/src/templates/calendar.html
+++ b/src/templates/calendar.html
@@ -115,7 +115,8 @@
             {{#if currentYear.showClock}}
             <div class="time-display">
                 <span class="clock {{clockClass}}"></span>
-                {{localize 'FSC.Time.Current'}}: {{currentYear.currentTime.hour}}:{{currentYear.currentTime.minute}}:{{currentYear.currentTime.second}}
+                <span class="text">{{localize 'FSC.Time.Current'}}:</span>
+                <span class="time">{{currentYear.currentTime.hour}}:{{currentYear.currentTime.minute}}:{{currentYear.currentTime.second}}</span>
             </div>
             {{/if}}
             <div class="calendar-controls">


### PR DESCRIPTION
Added a new time-keeper to be used as the clock. This new clock will update the time for users every second and save the time every 10 seconds (which will sync across all players). It also attempts to correct itself if the GM disconnects while it is running.
Reworked the foundation functions for calculating a date to a number of days (which is used to calculate timestamp, day of week, moon phases) This update adds support for negative timestamps (relative to the year zero) and negative years (regardless of year zero) and a negative year zero. This greatly increases the accuracy of the timestamp calculations.
Changed the behaviour so that when the time is updated it will not snap users  back to viewing the current date if they were browsing around, unless the GM deliberately changes the day/month/year.
Fixed a bug where occasionally the last day of the month would have a value of -1
API Changes
Updated the showCalendar function so it has a new parameter to open the calendar in compact mode.
Updated the setDate function so that any unprovided parameters default to the current date equivalent.
Added a new function dateToTimestamp to convert a date to timestamp without altering the current date.
added a new function isPrimaryGM
added a hook that fires when the primaryGM is set.
added new api functions to start/stop the clock.
Updated all the API functions to assure they account for the PF2E system.

Updated all of the unit tests for the new changes and expanded them greatly for the core date to days function to.

Updated all of the documentation around API and hooks for those new/updated functions.