### PR TITLE
v1.2.997

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## v1.2.97 - API Bug Fixes
+
+- Fixed a bug with the API function timestampPlusInterval where adding just a year would increment to the first day of the year not by the number of years.
+- Fixed a bug with the API function timestampPlusInterval where if very large values for the different intervals were passed in an error would be thrown
+
 ## v1.2.95 - Translations & Foundry 0.8.7
 
 - Ensured that Simple Calendar works in foundry version 0.8.7.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "foundryvtt-simple-calendar",
   "description": "A simple calendar module for keeping track of game days and events.",
-  "version": "1.2.95",
+  "version": "1.2.97",
   "author": "Dean Vigoren (vigorator)",
   "keywords": [
     "foundryvtt",

--- a/src/classes/api.test.ts
+++ b/src/classes/api.test.ts
@@ -60,6 +60,12 @@ describe('API Class Tests', () => {
 
         expect(API.timestampPlusInterval(0, {second: 86401})).toBe(86401);
 
+        expect(API.timestampPlusInterval(0, {month: 3})).toBe(7862400);
+        expect(API.timestampPlusInterval(0, {hour: 2184})).toBe(7862400);
+        expect(API.timestampPlusInterval(0, {minute: 131040})).toBe(7862400);
+        expect(API.timestampPlusInterval(0, {second: 7862400})).toBe(7862400);
+        expect(API.timestampPlusInterval(86399, {second: 1})).toBe(86400);
+
         year.gameSystem = GameSystems.PF2E;
         year.generalSettings.pf2eSync = true;
         expect(API.timestampPlusInterval(0, {day: 0})).toBe(0);

--- a/src/classes/year.test.ts
+++ b/src/classes/year.test.ts
@@ -520,6 +520,16 @@ describe('Year Class Tests', () => {
         expect(year.months[1].days[21].selected).toBe(false);
     });
 
+    test('Change Day Bulk', () => {
+        year.months.push(month);
+        month.current = true;
+        month.days[0].current = true;
+        year.changeDayBulk(1);
+        expect(year.months[0].days[1].current).toBe(true);
+        year.changeDayBulk(31);
+        expect(year.numericRepresentation).toBe(1);
+    });
+
     test('Change Time', () => {
         year.changeTime(true, 'hour');
         expect(year.time.seconds).toBe(3600);

--- a/src/classes/year.ts
+++ b/src/classes/year.ts
@@ -525,6 +525,23 @@ export default class Year {
     }
 
     /**
+     * Changes the current or selected day by the passed in amount. Adjusting for number of years first
+     * @param amount
+     * @param setting
+     */
+    changeDayBulk(amount: number, setting: string = 'current'){
+        let isLeapYear = this.leapYearRule.isLeapYear(this.numericRepresentation);
+        let numberOfDays = this.totalNumberOfDays(isLeapYear, true);
+        while(amount > numberOfDays){
+            this.changeYear(1, false, setting);
+            amount -= numberOfDays;
+            isLeapYear = this.leapYearRule.isLeapYear(this.numericRepresentation);
+            numberOfDays = this.totalNumberOfDays(isLeapYear, true);
+        }
+        this.changeDay(amount, setting);
+    }
+
+    /**
      * Changes the passed in time type by the passed in amount
      * @param {boolean} next If we are going forward or backwards
      * @param {string} type The time type we are adjusting, can be hour, minute or second

--- a/src/module.json
+++ b/src/module.json
@@ -2,7 +2,7 @@
   "name": "foundryvtt-simple-calendar",
   "title": "Simple Calendar",
   "description": "A simple calendar module for keeping track of game days and events.",
-  "version": "1.2.95",
+  "version": "1.2.97",
   "author": "Dean Vigoren (Vigorator)",
   "authors": [
     {


### PR DESCRIPTION
Fixed a bug with api.timestampPlusInterval where year changes would set to january 1.

Fixed a bug with api.timestampPlusInterval where very large values for the different intervals would cause an error to be thrown.
Updated the unit tests.