### PR TITLE
v1.2.113

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## v1.2.113 - API Changes
+
+- Updated the timestampToDate function's return values. The result now contains a display object that contains all the different display strings for the passed in timestamp.
+- Fixed a bug with the timestampToDate function where months with day offsets would return the incorrect day of the week for days in that month.
+- Fixed a bug with the timestampToDate function where the "showWeekdayHeadings" property would be incorrectly set.
+- Added a function SimpleCalendar.api.getCurrentSeason() that returns details about the season for the current date.
+- Added a function SimpleCalendar.api.getAllSeasons() that returns details for every configured season in Simple Calendar.
+- Fixed a bug when importing from Calendar/weather where the hours per day would end up being undefined.
+
 ## v1.2.107 - Calendar Configuration Import/Export, API Changes, Bug Fixes
 
 ### Import/Export

--- a/docs/API.md
+++ b/docs/API.md
@@ -312,22 +312,38 @@ The date object that is return has the following properties:
 Property|Type|Default Value|Description
 ---------|-----|-------------|-----------
 year|Number|0|The year represented in the timestamp.
-yearName|String|""|The name of the year, if year names have been set up.
+yearName|String|""|**Depreciated** Please use display.yearName instead. This will be removed when Foundry v9 Stable is released.
 month|Number|0|The index of the month represented in the timestamp.
-monthName|String|""|The name of the month.
+monthName|String|""|**Depreciated** Please use display.monthName instead. This will be removed when Foundry v9 Stable is released.
 dayOffset|Number|0|The number of days that the months days are offset by.
 day|Number|0|The index of the day of the month represented in the timestamp.
-dayDisplay|String|""|How the day is displayed, generally its number on the calendar.
+dayDisplay|String|""|**Depreciated** Please use display.day instead. This will be removed when Foundry v9 Stable is released.
 dayOfTheWeek|Number|0|The day of the week the day falls on.
 hour|Number|0|The hour represented in the timestamp.
 minute|Number|0|The minute represented in the timestamp.
 second|Number|0|The seconds represented in the timestamp.
 yearZero|Number|0|What is considered as year zero when doing timestamp calculations.
-yearPrefix|String|""|The prefix value for the year
-yearPostfix|String|""|The postfix value for the year
+yearPrefix|String|""|**Depreciated** Please use display.yearPrefix instead. This will be removed when Foundry v9 Stable is released.
+yearPostfix|String|""|**Depreciated** Please use display.yearPostfix instead. This will be removed when Foundry v9 Stable is released.
 weekdays|String Array|[]|A list of weekday names.
 showWeekdayHeadings|Boolean|true|If to show the weekday headings for the month.
 currentSeason|Season|{}|The information for the season of the date, properties include "name" for the seasons name and "color" for the color associated with the season.
+display|Display Object|{}|All of the strings associated with displaying the date are put here
+
+#### Display object
+
+Property|Type|Default Value|Description
+---------|-----|-------------|-----------
+year|String|""|The year number
+yearName|String|""|The name of the year, if year names have been set up.
+yearPrefix|String|""|The prefix value for the year
+yearPostfix|String|""|The postfix value for the year
+month|String|""|The month number.
+monthName|String|""|The name of the month.
+weekday|String|""|The name of the weekday this date falls on.
+day|String|""|How the day is displayed, generally its number on the calendar.
+daySuffix|String|""|The Ordinal Suffix associated with the day number (st, nd, rd or th)
+time|String|''|The hour, minute and seconds.
 
 ### Examples
 

--- a/src/classes/api.test.ts
+++ b/src/classes/api.test.ts
@@ -18,6 +18,8 @@ import {Weekday} from "./weekday";
 import {GameSystems, LeapYearRules} from "../constants";
 import SpyInstance = jest.SpyInstance;
 import Mock = jest.Mock;
+import Season from "./season";
+jest.spyOn(console, 'error').mockImplementation(() => {});
 
 
 describe('API Class Tests', () => {
@@ -75,18 +77,18 @@ describe('API Class Tests', () => {
     });
 
     test('Timestamp to Date', () => {
-        expect(API.timestampToDate(3600)).toStrictEqual({year: 0, month: 0, day: 0, dayOfTheWeek: 0, hour: 0, minute: 0, second: 0, monthName: "", yearName: "", yearZero: 0, weekdays: [], currentSeason: {}, showWeekdayHeadings: true, yearPostfix: '', yearPrefix: '', dayOffset: 0, dayDisplay: ''});
+        expect(API.timestampToDate(3600)).toStrictEqual({year: 0, month: 0, day: 0, dayOfTheWeek: 0, hour: 0, minute: 0, second: 0, monthName: "", yearName: "", yearZero: 0, weekdays: [], currentSeason: {}, showWeekdayHeadings: true, yearPostfix: '', yearPrefix: '', dayOffset: 0, dayDisplay: '', "display": {"day": "", "daySuffix": "", "month": "", "monthName": "", "weekday": "", "year": "", "yearName": "", "yearPostfix": "", "yearPrefix": "", time:""}});
         SimpleCalendar.instance.currentYear = year;
         year.weekdays.push(new Weekday(1, 'W1'));
-        expect(API.timestampToDate(3600)).toStrictEqual({year: 0, month: 0, day: 0, dayOfTheWeek: 0, hour: 1, minute: 0, second: 0, monthName: "M1", yearName: "", yearZero: 0, weekdays: ["W1"], currentSeason: {color: '', name: ''}, showWeekdayHeadings: true, yearPostfix: '', yearPrefix: '', dayOffset: 0, dayDisplay: '1'});
-        expect(API.timestampToDate(5184000)).toStrictEqual({year: 1, month: 0, day: 0, dayOfTheWeek: 0, hour: 0, minute: 0, second: 0, monthName: "M1", yearName: "", yearZero: 0, weekdays: ["W1"], currentSeason: {color: '', name: ''}, showWeekdayHeadings: true, yearPostfix: '', yearPrefix: '', dayOffset: 0, dayDisplay: '1'});
-        expect(API.timestampToDate(5270400)).toStrictEqual({year: 1, month: 0, day: 1, dayOfTheWeek: 0, hour: 0, minute: 0, second: 0, monthName: "M1", yearName: "", yearZero: 0, weekdays: ["W1"], currentSeason: {color: '', name: ''}, showWeekdayHeadings: true, yearPostfix: '', yearPrefix: '', dayOffset: 0, dayDisplay: '2'});
+        expect(API.timestampToDate(3600)).toStrictEqual({year: 0, month: 0, day: 0, dayOfTheWeek: 0, hour: 1, minute: 0, second: 0, monthName: "M1", yearName: "", yearZero: 0, weekdays: ["W1"], currentSeason: {color: '', name: ''}, showWeekdayHeadings: true, yearPostfix: '', yearPrefix: '', dayOffset: 0, dayDisplay: '1', "display": {"day": "1", "daySuffix": "st", "month": "1", "monthName": "M1", "weekday": "W1", "year": "0", "yearName": "", "yearPostfix": "", "yearPrefix": "", time:"00:00:00"}});
+        expect(API.timestampToDate(5184000)).toStrictEqual({year: 1, month: 0, day: 0, dayOfTheWeek: 0, hour: 0, minute: 0, second: 0, monthName: "M1", yearName: "", yearZero: 0, weekdays: ["W1"], currentSeason: {color: '', name: ''}, showWeekdayHeadings: true, yearPostfix: '', yearPrefix: '', dayOffset: 0, dayDisplay: '1', "display": {"day": "1", "daySuffix": "st", "month": "1", "monthName": "M1", "weekday": "W1", "year": "1", "yearName": "", "yearPostfix": "", "yearPrefix": "", time:"00:00:00"}});
+        expect(API.timestampToDate(5270400)).toStrictEqual({year: 1, month: 0, day: 1, dayOfTheWeek: 0, hour: 0, minute: 0, second: 0, monthName: "M1", yearName: "", yearZero: 0, weekdays: ["W1"], currentSeason: {color: '', name: ''}, showWeekdayHeadings: true, yearPostfix: '', yearPrefix: '', dayOffset: 0, dayDisplay: '2', "display": {"day": "2", "daySuffix": "nd", "month": "1", "monthName": "M1", "weekday": "W1", "year": "1", "yearName": "", "yearPostfix": "", "yearPrefix": "", time:"00:00:00"}});
 
         year.gameSystem = GameSystems.PF2E;
         year.generalSettings.pf2eSync = true;
-        expect(API.timestampToDate(3600)).toStrictEqual({year: -1, month: 1, day: 29, dayOfTheWeek: 0, hour: 1, minute: 0, second: 0, monthName: "M2", yearName: "", yearZero: 0, weekdays: ["W1"], currentSeason: {color: '', name: ''}, showWeekdayHeadings: true, yearPostfix: '', yearPrefix: '', dayOffset: 0, dayDisplay: '30'});
-        expect(API.timestampToDate(5184000)).toStrictEqual({year: 0, month: 1, day: 29, dayOfTheWeek: 0, hour: 0, minute: 0, second: 0, monthName: "M2", yearName: "", yearZero: 0, weekdays: ["W1"], currentSeason: {color: '', name: ''}, showWeekdayHeadings: true, yearPostfix: '', yearPrefix: '', dayOffset: 0, dayDisplay: '30'});
-        expect(API.timestampToDate(5270400)).toStrictEqual({year: 1, month: 0, day: 0, dayOfTheWeek: 0, hour: 0, minute: 0, second: 0, monthName: "M1", yearName: "", yearZero: 0, weekdays: ["W1"], currentSeason: {color: '', name: ''}, showWeekdayHeadings: true, yearPostfix: '', yearPrefix: '', dayOffset: 0, dayDisplay: '1'});
+        expect(API.timestampToDate(3600)).toStrictEqual({year: -1, month: 1, day: 29, dayOfTheWeek: 0, hour: 1, minute: 0, second: 0, monthName: "M2", yearName: "", yearZero: 0, weekdays: ["W1"], currentSeason: {color: '', name: ''}, showWeekdayHeadings: true, yearPostfix: '', yearPrefix: '', dayOffset: 0, dayDisplay: '30', "display": {"day": "30", "daySuffix": "th", "month": "2", "monthName": "M2", "weekday": "W1", "year": "-1", "yearName": "", "yearPostfix": "", "yearPrefix": "", time:"00:00:00"}});
+        expect(API.timestampToDate(5184000)).toStrictEqual({year: 0, month: 1, day: 29, dayOfTheWeek: 0, hour: 0, minute: 0, second: 0, monthName: "M2", yearName: "", yearZero: 0, weekdays: ["W1"], currentSeason: {color: '', name: ''}, showWeekdayHeadings: true, yearPostfix: '', yearPrefix: '', dayOffset: 0, dayDisplay: '30', "display": {"day": "30", "daySuffix": "th", "month": "2", "monthName": "M2", "weekday": "W1", "year": "0", "yearName": "", "yearPostfix": "", "yearPrefix": "", time:"00:00:00"}});
+        expect(API.timestampToDate(5270400)).toStrictEqual({year: 1, month: 0, day: 0, dayOfTheWeek: 0, hour: 0, minute: 0, second: 0, monthName: "M1", yearName: "", yearZero: 0, weekdays: ["W1"], currentSeason: {color: '', name: ''}, showWeekdayHeadings: true, yearPostfix: '', yearPrefix: '', dayOffset: 0, dayDisplay: '1', "display": {"day": "1", "daySuffix": "st", "month": "1", "monthName": "M1", "weekday": "W1", "year": "1", "yearName": "", "yearPostfix": "", "yearPrefix": "", time:"00:00:00"}});
     });
 
     test('Date to Timestamp', () => {
@@ -228,6 +230,24 @@ describe('API Class Tests', () => {
         expect(API.stopClock()).toBe(false);
         SimpleCalendar.instance.currentYear = year;
         expect(API.stopClock()).toBe(true);
+    });
+
+    test('Get Current Season', () => {
+        expect(API.getCurrentSeason()).toStrictEqual({name:'', color: ''});
+        SimpleCalendar.instance.currentYear = year;
+        year.seasons.push(new Season('s1', 1, 1));
+        expect(API.getCurrentSeason()).toStrictEqual({name:'s1', color: '#ffffff'});
+        year.months[0].days[0].current = false;
+        expect(API.getCurrentSeason()).toStrictEqual({name:'', color: ''});
+        year.months[0].current = false;
+        expect(API.getCurrentSeason()).toStrictEqual({name:'', color: ''});
+    });
+
+    test('Get All Seasons', () => {
+        expect(API.getAllSeasons().length).toBe(0);
+        SimpleCalendar.instance.currentYear = year;
+        year.seasons.push(new Season('s1', 1, 1));
+        expect(API.getAllSeasons().length).toBe(1);
     });
 
     test('Calendar Weather Import', async () => {

--- a/src/classes/api.ts
+++ b/src/classes/api.ts
@@ -5,6 +5,7 @@ import {GameSettings} from "./game-settings";
 import {GameSystems, TimeKeeperStatus} from "../constants";
 import PF2E from "./systems/pf2e";
 import Importer from "./importer";
+import Utilities from "./utilities";
 
 /**
  * All external facing functions for other systems, modules or macros to consume
@@ -83,21 +84,33 @@ export default class API{
         const result = {
             year: 0,
             month: 0,
-            monthName: "",
             dayOffset: 0,
             day: 0,
-            dayDisplay: '',
             dayOfTheWeek: 0,
             hour: 0,
             minute: 0,
             second: 0,
-            yearName: "",
             yearZero: 0,
             weekdays: <string[]>[],
             showWeekdayHeadings: true,
+            currentSeason: {},
+            monthName: "",
+            dayDisplay: '',
+            yearName: "",
             yearPrefix: '',
             yearPostfix: '',
-            currentSeason: {}
+            display: {
+                day: '',
+                daySuffix: '',
+                weekday: '',
+                monthName: '',
+                month: '',
+                year: '',
+                yearName: '',
+                yearPrefix: '',
+                yearPostfix: '',
+                time: ''
+            }
         };
         if(SimpleCalendar.instance && SimpleCalendar.instance.currentYear){
             // If this is a Pathfinder 2E game, add the world creation seconds
@@ -115,16 +128,32 @@ export default class API{
             result.second = dateTime.seconds;
 
             const month = SimpleCalendar.instance.currentYear.months[dateTime.month];
-            result.monthName = month.name;
+            const day = month.days[dateTime.day];
             result.dayOffset = month.numericRepresentationOffset;
             result.yearZero = SimpleCalendar.instance.currentYear.yearZero;
+            result.dayOfTheWeek = SimpleCalendar.instance.currentYear.dayOfTheWeek(result.year, month.numericRepresentation, day.numericRepresentation);
+            result.currentSeason = SimpleCalendar.instance.currentYear.getSeason(dateTime.month, dateTime.day + 1);
+            result.weekdays = SimpleCalendar.instance.currentYear.weekdays.map(w => w.name);
+            result.showWeekdayHeadings = SimpleCalendar.instance.currentYear.showWeekdayHeadings;
+
+            // Display Stuff
+            // Legacy - Depreciated first stable release of Foundry 9
+            result.monthName = month.name;
             result.yearName = SimpleCalendar.instance.currentYear.getYearName(result.year);
             result.yearPrefix = SimpleCalendar.instance.currentYear.prefix;
             result.yearPostfix = SimpleCalendar.instance.currentYear.postfix;
-            result.dayDisplay = SimpleCalendar.instance.currentYear.months[dateTime.month].days[dateTime.day].numericRepresentation.toString();
-            result.dayOfTheWeek = SimpleCalendar.instance.currentYear.dayOfTheWeek(result.year, month.numericRepresentation, dateTime.day + 1);
-            result.weekdays = SimpleCalendar.instance.currentYear.weekdays.map(w => w.name);
-            result.currentSeason = SimpleCalendar.instance.currentYear.getSeason(dateTime.month, dateTime.day + 1);
+            result.dayDisplay = day.numericRepresentation.toString();
+
+            result.display.year = dateTime.year.toString();
+            result.display.yearName = SimpleCalendar.instance.currentYear.getYearName(result.year);
+            result.display.yearPrefix = SimpleCalendar.instance.currentYear.prefix;
+            result.display.yearPostfix = SimpleCalendar.instance.currentYear.postfix;
+            result.display.month = month.numericRepresentation.toString();
+            result.display.monthName = month.name;
+            result.display.weekday = SimpleCalendar.instance.currentYear.weekdays[result.dayOfTheWeek].name;
+            result.display.day = day.numericRepresentation.toString();
+            result.display.daySuffix = Utilities.ordinalSuffix(day.numericRepresentation);
+            result.display.time = SimpleCalendar.instance.currentYear.time.toString();
         }
         return result;
     }
@@ -409,12 +438,12 @@ export default class API{
             }
         }
         return {
-          year: year,
-          month: month,
-          day: day,
-          hour: hour,
-          minute: minute,
-          second: second
+            year: year,
+            month: month,
+            day: day,
+            hour: hour,
+            minute: minute,
+            second: second
         };
     }
 
@@ -450,6 +479,32 @@ export default class API{
         return false;
     }
 
+    /**
+     * Returns the season for the current date
+     */
+    public static getCurrentSeason(){
+        if(SimpleCalendar.instance && SimpleCalendar.instance.currentYear){
+            const mon = SimpleCalendar.instance.currentYear.getMonth();
+            if(mon){
+                const mIndex = SimpleCalendar.instance.currentYear.months.findIndex(m => m.numericRepresentation = mon.numericRepresentation);
+                const day = mon.getDay();
+                if(day){
+                    return SimpleCalendar.instance.currentYear.getSeason(mIndex, day.numericRepresentation);
+                }
+            }
+        }
+        return {name: '', color: ''};
+    }
+
+    /**
+     * Returns details for all seasons set up in the calendar
+     */
+    public static getAllSeasons(){
+        if(SimpleCalendar.instance && SimpleCalendar.instance.currentYear){
+            return SimpleCalendar.instance.currentYear.seasons;
+        }
+        return [];
+    }
 
     /**
      * This is only here until Calendar Weather has finished their migration from about-time functions to Simple Calendar functions. At which point it will be removed.

--- a/src/classes/importer.test.ts
+++ b/src/classes/importer.test.ts
@@ -214,7 +214,7 @@ describe('Importer Class Tests', () => {
         (<Mock>game.settings.get).mockReturnValueOnce(mockCalendarWeather);
         Importer.importCalendarWeather(y);
 
-        expect(y.time.hoursInDay).toBe(12);
+        //expect(y.time.hoursInDay).toBe(12);
         expect(y.time.minutesInHour).toBe(60);
         expect(y.time.secondsInMinute).toBe(60);
         expect(y.weekdays.length).toBe(3);

--- a/src/classes/importer.ts
+++ b/src/classes/importer.ts
@@ -158,7 +158,7 @@ export default class Importer{
         const currentSettings = <CalendarWeatherImport.Calendar> game.settings.get('calendar-weather', 'dateTime');
 
         //Set up the time
-        year.time.hoursInDay = currentSettings.dayLength;
+        //year.time.hoursInDay = currentSettings.dayLength;
 
         //Set up the weekdays
         year.weekdays = [];

--- a/src/classes/utilities.test.ts
+++ b/src/classes/utilities.test.ts
@@ -1,0 +1,33 @@
+import Utilities from "./utilities";
+
+describe('Utilities Class Tests', () => {
+
+    test('Random Hash', () => {
+        expect(Utilities.randomHash('')).toBe(0);
+        expect(Utilities.randomHash('asd')).not.toBe(0);
+    });
+
+    test('Ordinal Suffix', () => {
+        expect(Utilities.ordinalSuffix(0)).toBe('th');
+        expect(Utilities.ordinalSuffix(1)).toBe('st');
+        expect(Utilities.ordinalSuffix(2)).toBe('nd');
+        expect(Utilities.ordinalSuffix(3)).toBe('rd');
+        expect(Utilities.ordinalSuffix(4)).toBe('th');
+        expect(Utilities.ordinalSuffix(5)).toBe('th');
+        expect(Utilities.ordinalSuffix(6)).toBe('th');
+        expect(Utilities.ordinalSuffix(7)).toBe('th');
+        expect(Utilities.ordinalSuffix(8)).toBe('th');
+        expect(Utilities.ordinalSuffix(9)).toBe('th');
+        expect(Utilities.ordinalSuffix(10)).toBe('th');
+        expect(Utilities.ordinalSuffix(11)).toBe('th');
+        expect(Utilities.ordinalSuffix(12)).toBe('th');
+        expect(Utilities.ordinalSuffix(13)).toBe('th');
+        expect(Utilities.ordinalSuffix(14)).toBe('th');
+        expect(Utilities.ordinalSuffix(21)).toBe('st');
+        expect(Utilities.ordinalSuffix(22)).toBe('nd');
+        expect(Utilities.ordinalSuffix(23)).toBe('rd');
+        expect(Utilities.ordinalSuffix(111)).toBe('th');
+        expect(Utilities.ordinalSuffix(112)).toBe('th');
+        expect(Utilities.ordinalSuffix(113)).toBe('th');
+    });
+});

--- a/src/classes/utilities.ts
+++ b/src/classes/utilities.ts
@@ -1,0 +1,28 @@
+export default class Utilities{
+
+    /**
+     * Generates a random numeric value based on the passed in string.
+     * @param {string} value The string to hash
+     * @return {number} The number representing the hash value
+     */
+    public static randomHash(value: string) {
+        let hash = 0;
+        if (value.length == 0) {
+            return hash;
+        }
+        for (let i = 0; i < value.length; i++) {
+            let char = value.charCodeAt(i);
+            hash = ((hash<<5)-hash)+char;
+            hash = hash & hash; // Convert to 32bit integer
+        }
+        return hash;
+    }
+
+    /**
+     * Returns the ordinal suffix for the passed in number
+     * @param {number} n The number to get the suffix for
+     */
+    public static ordinalSuffix(n: number): string {
+        return [undefined,'st','nd','rd'][n%100>>3^1&&n%10]||'th';
+    }
+}

--- a/src/classes/year.test.ts
+++ b/src/classes/year.test.ts
@@ -620,6 +620,7 @@ describe('Year Class Tests', () => {
         year.months.push(new Month("Test 3", 3, 0, 30));
         expect(year.dateToDays(0,1,-1)).toBe(0);
         expect(year.dateToDays(5,1,1)).toBe(450);
+        expect(year.dateToDays(5,11,1)).toBe(450);
         year.leapYearRule = new LeapYear();
         year.leapYearRule.rule = LeapYearRules.Gregorian;
         expect(year.dateToDays(5,1,1, true)).toBe(452);
@@ -1041,11 +1042,6 @@ describe('Year Class Tests', () => {
         year.yearNamingRule = YearNamingRules.Random;
         expect(year.getYearName(4)).not.toBe('');
 
-    });
-
-    test('Random Hash', () => {
-        expect(year.randomHash('')).toBe(0);
-        expect(year.randomHash('asd')).not.toBe(0);
     });
 
 });

--- a/src/classes/year.ts
+++ b/src/classes/year.ts
@@ -18,6 +18,7 @@ import Moon from "./moon";
 import {Note} from "./note";
 import SimpleCalendar from "./simple-calendar";
 import PF2E from "./systems/pf2e";
+import Utilities from "./utilities";
 
 /**
  * Class for representing a year
@@ -1007,7 +1008,7 @@ export default class Year {
             if(this.yearNamingRule === YearNamingRules.Repeat){
                 nameIndex = (((yearToUse - this.yearNamesStart) % this.yearNames.length) + this.yearNames.length) % this.yearNames.length;
             } else if(this.yearNamingRule === YearNamingRules.Random){
-                const yearHash = this.randomHash(`${yearToUse}-AbCxYz`);
+                const yearHash = Utilities.randomHash(`${yearToUse}-AbCxYz`);
                 nameIndex = (((yearHash - this.yearNamesStart) % this.yearNames.length) + this.yearNames.length) % this.yearNames.length;
             } else {
                 nameIndex = Math.abs(this.yearNamesStart - yearToUse);
@@ -1019,23 +1020,5 @@ export default class Year {
         }
 
         return name;
-    }
-
-    /**
-     * Generates a random numeric value based on the passed in string.
-     * @param {string} value The string to hash
-     * @return {number} The number representing the hash value
-     */
-    randomHash(value: string) {
-        let hash = 0;
-        if (value.length == 0) {
-            return hash;
-        }
-        for (let i = 0; i < value.length; i++) {
-            let char = value.charCodeAt(i);
-            hash = ((hash<<5)-hash)+char;
-            hash = hash & hash; // Convert to 32bit integer
-        }
-        return hash;
     }
 }


### PR DESCRIPTION
Moved some functions to a new utilities class.
Changed the import from calendar/weather to ignore the hours in a day, as it is sometimes undefined and there is no way to change it from 24 hours.
Fixed an issue with the api timestampToDate where the showeekdayHeadings was always true.
Fixed an issue with the API teimstampToDate where months with day offsets would return the incorrect day of the week.
Added functions to the api to get the current seasons information as well as get all seasons information.

Closes #147 