### PR TITLE
Translations update from Foundry Hub - Weblate

### DIFF
--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -520,5 +520,14 @@
 	"FSC.Configuration.Month.DescriptionHelp": "Une description de la saison pour donner plus de saveur à votre calendrier. Ces informations sont visibles lorsqu'un utilisateur clique sur le nom de la saison dans la vue principale du calendrier.",
 	"FSC.Configuration.Season.DescriptionField": "Description de la saison",
 	"FSC.Configuration.Season.DescriptionHelp": "Une description de la saison pour donner plus de saveur à votre calendrier. Ces informations sont visibles lorsqu'un utilisateur clique sur le nom de la saison dans la vue principale du calendrier.",
-	"FSC.Configuration.Weekday.DescriptionHelp": "Une description du jour de la semaine pour donner plus de saveur à votre calendrier. Ces informations sont visibles lorsqu'un utilisateur clique sur le nom d'un jour de la semaine dans la vue principale du calendrier."
+	"FSC.Configuration.Weekday.DescriptionHelp": "Une description du jour de la semaine pour donner plus de saveur à votre calendrier. Ces informations sont visibles lorsqu'un utilisateur clique sur le nom d'un jour de la semaine dans la vue principale du calendrier.",
+	"FSC.Right": "Droite",
+	"FSC.Configuration.Client.RememberCompactPosition.Title": "Se souvenir de la position compacte",
+	"FSC.Configuration.Client.RememberCompactPosition.Description": "Simple Calendar se souviendra où la version compacte a été placée pour la dernière fois et s'y placera de lui-même en mode compact. C'est un emplacement différent de la version complète.",
+	"FSC.Predefined.Starfinder": "Starfinder",
+	"FSC.Left": "Gauche",
+	"FSC.Down": "Bas",
+	"FSC.Configuration.Client.NoteListOpenDirection.Title": "Direction de l'ouverture du tiroir latéral",
+	"FSC.Configuration.Client.NoteListOpenDirection.Description": "La direction dans laquelle le tiroir latéral du calendrier principal s'ouvrira. Le tiroir latéral contient les listes de calendrier, de note et la recherche de note.",
+	"FSC.Predefined.Warhammer40kWG": "Warhammer 40,000 : Wrath & Glory"
 }

--- a/src/lang/pt-BR.json
+++ b/src/lang/pt-BR.json
@@ -519,5 +519,14 @@
 	"FSC.Configuration.Season.DescriptionHelp": "Uma descrição sobre a estação para dar mais sabor ao seu calendário. Essas informações ficam visíveis quando um usuário clica no nome da estação na visualização principal do calendário.",
 	"FSC.Configuration.Weekday.Weekend": "Dia de descanso",
 	"FSC.Configuration.Weekday.WeekendHelp": "A parte da semana que é tradicionalmente dedicada ao descanso, ao invés do trabalho. por exemplo. O fim de semana no calendário gregoriano moderno",
-	"FSC.Configuration.Weekday.DescriptionHelp": "Uma descrição sobre o dia da semana para dar mais sabor ao seu calendário. Essas informações ficam visíveis quando um usuário clica no nome de um dia da semana na visualização principal do calendário."
+	"FSC.Configuration.Weekday.DescriptionHelp": "Uma descrição sobre o dia da semana para dar mais sabor ao seu calendário. Essas informações ficam visíveis quando um usuário clica no nome de um dia da semana na visualização principal do calendário.",
+	"FSC.Configuration.Client.NoteListOpenDirection.Description": "A direção do calendário principal em que as gavetas laterais serão abertas. As gavetas laterais contêm a lista de calendários, lista de notas e pesquisa de notas.",
+	"FSC.Predefined.Starfinder": "Starfinder",
+	"FSC.Right": "Direita",
+	"FSC.Left": "Esquerda",
+	"FSC.Down": "Para baixo",
+	"FSC.Configuration.Client.RememberCompactPosition.Title": "Lembrar posição compacta",
+	"FSC.Configuration.Client.RememberCompactPosition.Description": "O Simple Calendar lembrará onde a versão compacta foi posicionada pela última vez e se colocará lá quando estiver no modo compacto. Esta é uma posição separada da versão completa.",
+	"FSC.Configuration.Client.NoteListOpenDirection.Title": "Direção de Abertura da Gaveta Lateral",
+	"FSC.Predefined.Warhammer40kWG": "Warhammer 40,000 Roleplay: Wrath & Glory"
 }


### PR DESCRIPTION
Translations update from [Foundry Hub - Weblate](https://weblate.foundryvtt-hub.com) for [Simple Calendar/main](https://weblate.foundryvtt-hub.com/projects/simple-calendar/main/).



Current translation status:

![Weblate translation status](https://weblate.foundryvtt-hub.com/widgets/simple-calendar/-/main/horizontal-auto.svg)