### PR TITLE
Disabling calendar auto-open on load

### DIFF
--- a/src/classes/applications/configuration-app.ts
+++ b/src/classes/applications/configuration-app.ts
@@ -81,7 +81,7 @@ export default class ConfigurationApp extends FormApplication {
     private clientSettings: SimpleCalendar.ClientSettingsData = {
         id: '',
         theme: Themes[0].key,
-        openOnLoad: true,
+        openOnLoad: false,
         openCompact: false,
         rememberPosition: true,
         rememberCompactPosition: false,

--- a/src/classes/applications/migration-app.ts
+++ b/src/classes/applications/migration-app.ts
@@ -167,7 +167,7 @@ export default class MigrationApp extends Application{
         SC.save(SC.globalConfiguration, {
             id: '',
             theme: Themes[0].key,
-            openOnLoad: true,
+            openOnLoad: false,
             openCompact: false,
             rememberPosition: true,
             rememberCompactPosition: false,

--- a/src/classes/s-c-controller.ts
+++ b/src/classes/s-c-controller.ts
@@ -54,7 +54,7 @@ export default class SCController {
         this.clientSettings = {
             id: '',
             theme: Themes[0].key,
-            openOnLoad: true,
+            openOnLoad: false,
             openCompact: false,
             rememberPosition: true,
             rememberCompactPosition: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,9 +74,9 @@ Hooks.on('ready',async () => {
         //Initialize the Simple Calendar Class
         SC.initialize();
         //If we are to open the main app on foundry load, open it
-        if(SC.clientSettings.openOnLoad){
-            MainApplication.render();
-        }
+        //if(SC.clientSettings.openOnLoad){
+            //MainApplication.render();
+        //}
     }
     Hook.emit(SimpleCalendarHooks.Ready, CalManager.getActiveCalendar());
 });


### PR DESCRIPTION
A hasty bugfix for those experiencing #488 , and a quality-of-life improvement (in my opinion).

It seems setting the default value of 'openOnLoad' to false did not solve the bug. The setting still reverts to 'true' on every new session of play. I am at a loss as to why. As such, I disabled the auto-opening of the calendar at load directly until a more permanent solution can be found.

Besides the bug I find it in my taste that the 'openOnLoad' should be set to false as a default for all users. Especially new users of Foundry can be overwhelmed with popups and not be sure how to disable the setting. As such, it falls to the GM to guide the player through the configuration process. Yes, it can be a two-click process right now, but in my experience the conversation tends to go something like this:

Player: "Why does the calendar pop open every time we play?"
GM: "You can turn that off in the settings menu of the calendar."
Player: "Oh, where was that? I just closed the calendar."
GM: "It's in the Journal Notes tab, then click Simple Calendar."
Player: "Journal Notes tab?"
GM: "It's the banner looking button on the left of the screen. Click that."
Player: "I see it. Ah there, I have it open now."
GM: "Now click the cogwheel button and then set Open On Load to off. It's in the upper part of the settings that will appear."
Player: "Ah, got it! But now I can't select any tokens?"
GM: "Now you should turn Token Controls back on. It's the uhh... person looking icon near the top left. Like above where the Journal Notes button is. The top left one."
Player: "Got it, thanks!"
Player 2: "Wait GM, can you guide me through that process too? I wasn't paying attention."
GM: *dies* 