### PR TITLE
Warning in Foundry V12

### DIFF
--- a/src/module.json
+++ b/src/module.json
@@ -105,7 +105,6 @@
 		}
 	],
 	"socket": true,
-	"manifestPlusVersion": "1.2.0",
 	"media": [
 		{
 			"type": "setup",


### PR DESCRIPTION
The "Simple Calendar" module's manifest contained the following unknown keys: "manifestPlusVersion"
