### PR TITLE
FEATURE #597 Hide clock from players based on permissions

### DIFF
--- a/src/classes/applications/configuration-app.ts
+++ b/src/classes/applications/configuration-app.ts
@@ -771,6 +771,13 @@ export default class ConfigurationApp extends FormApplication {
                 false,
                 this.appWindow
             );
+            this.globalConfiguration.permissions.viewExactTime.player = getCheckBoxInputValue("#scViewExactTimeP", true, this.appWindow);
+            this.globalConfiguration.permissions.viewExactTime.trustedPlayer = getCheckBoxInputValue("#scViewExactTimeTP", true, this.appWindow);
+            this.globalConfiguration.permissions.viewExactTime.assistantGameMaster = getCheckBoxInputValue(
+                "#scViewExactTimeAGM",
+                true,
+                this.appWindow
+            );
 
             //----------------------------------
             // Calendar: Quick Setup

--- a/src/classes/applications/main-app.test.ts
+++ b/src/classes/applications/main-app.test.ts
@@ -1170,4 +1170,30 @@ describe("Main App Class Tests", () => {
         ma.sceneControlButtonClick();
         expect(ma.render).toHaveBeenCalledTimes(2);
     });
+
+    test("Time Displayed Only With Proper Permission", async () => {
+        jest.spyOn((game as Game).user as StoredDocument<User>, 'hasRole').mockImplementation((role) => role === 1);
+        tCal.generalSettings.showClock = true;
+
+        const permissionMock = jest.replaceProperty(SC.globalConfiguration.permissions, 'viewExactTime', {
+            player: false,
+            trustedPlayer: false,
+            assistantGameMaster: false
+        });
+
+        expect((await ma.getData() as Record<string, any>).showClock).toBe(false);
+
+        permissionMock.replaceValue({
+            player: true,
+            trustedPlayer: true,
+            assistantGameMaster: true
+        });
+
+        expect((await ma.getData() as Record<string, any>).showClock).toBe(true);
+
+        tCal.generalSettings.showClock = false;
+        expect((await ma.getData() as Record<string, any>).showClock).toBe(false);
+
+        permissionMock.restore();
+    });
 });

--- a/src/classes/applications/main-app.ts
+++ b/src/classes/applications/main-app.ts
@@ -138,7 +138,7 @@ export default class MainApp extends FormApplication {
             message: "",
             uiElementStates: this.uiElementStates,
             reorderNotes: canUser((<Game>game).user, SC.globalConfiguration.permissions.reorderNotes),
-            showClock: this.visibleCalendar.generalSettings.showClock,
+            showClock: this.visibleCalendar.generalSettings.showClock && canUser((<Game>game).user, SC.globalConfiguration.permissions.viewExactTime),
             showDateControls: false,
             showSetCurrentDate: false,
             showTimeControls: false,

--- a/src/classes/configuration/user-permissions.test.ts
+++ b/src/classes/configuration/user-permissions.test.ts
@@ -14,11 +14,13 @@ describe('User Permissions Class Tests', () => {
     });
 
     test('Properties', () => {
-        expect(Object.keys(up).length).toBe(11); //Make sure no new properties have been added
+        expect(Object.keys(up).length).toBe(12); //Make sure no new properties have been added
         expect(up.viewCalendar).toStrictEqual({player: true, trustedPlayer: true, assistantGameMaster: true, users: undefined});
         expect(up.addNotes).toStrictEqual({player: false, trustedPlayer: false, assistantGameMaster: false, users: undefined});
         expect(up.reorderNotes).toStrictEqual({player: false, trustedPlayer: false, assistantGameMaster: false, users: undefined});
         expect(up.changeDateTime).toStrictEqual({player: false, trustedPlayer: false, assistantGameMaster: false, users: undefined});
+        expect(up.changeActiveCalendar).toStrictEqual({player: false, trustedPlayer: false, assistantGameMaster: false, users: undefined});
+        expect(up.viewExactTime).toStrictEqual({player: true, trustedPlayer: true, assistantGameMaster: true, users: undefined});
     });
 
     test('Clone Permissions', () => {
@@ -38,6 +40,8 @@ describe('User Permissions Class Tests', () => {
         expect(template.addNotes).toStrictEqual(up.addNotes);
         expect(template.reorderNotes).toStrictEqual(up.reorderNotes);
         expect(template.changeDateTime).toStrictEqual(up.changeDateTime);
+        expect(template.changeActiveCalendar).toStrictEqual(up.changeActiveCalendar);
+        expect(template.viewExactTime).toStrictEqual(up.viewExactTime);
 
     });
     test('To Config', () => {
@@ -47,6 +51,8 @@ describe('User Permissions Class Tests', () => {
         expect(template.addNotes).toStrictEqual(up.addNotes);
         expect(template.reorderNotes).toStrictEqual(up.reorderNotes);
         expect(template.changeDateTime).toStrictEqual(up.changeDateTime);
+        expect(template.changeActiveCalendar).toStrictEqual(up.changeActiveCalendar);
+        expect(template.viewExactTime).toStrictEqual(up.viewExactTime);
     });
 
     test('Load From Settings', () => {

--- a/src/classes/configuration/user-permissions.ts
+++ b/src/classes/configuration/user-permissions.ts
@@ -22,6 +22,10 @@ export default class UserPermissions extends ConfigurationItemBase {
      * Which users can change the active calendar
      */
     changeActiveCalendar: SimpleCalendar.PermissionMatrix;
+    /**
+     * Which users can see the detailed time
+     */
+    viewExactTime: SimpleCalendar.PermissionMatrix;
 
     constructor() {
         super();
@@ -31,6 +35,7 @@ export default class UserPermissions extends ConfigurationItemBase {
         this.reorderNotes = { player: false, trustedPlayer: false, assistantGameMaster: false, users: undefined };
         this.changeDateTime = { player: false, trustedPlayer: false, assistantGameMaster: false, users: undefined };
         this.changeActiveCalendar = { player: false, trustedPlayer: false, assistantGameMaster: false, users: undefined };
+        this.viewExactTime = { player: true, trustedPlayer: true, assistantGameMaster: true, users: undefined };
     }
 
     /**
@@ -58,6 +63,7 @@ export default class UserPermissions extends ConfigurationItemBase {
         up.reorderNotes = UserPermissions.clonePermissions(this.reorderNotes);
         up.changeDateTime = UserPermissions.clonePermissions(this.changeDateTime);
         up.changeActiveCalendar = UserPermissions.clonePermissions(this.changeActiveCalendar);
+        up.viewExactTime = UserPermissions.clonePermissions(this.viewExactTime);
         return up;
     }
 
@@ -71,7 +77,8 @@ export default class UserPermissions extends ConfigurationItemBase {
             addNotes: this.addNotes,
             reorderNotes: this.reorderNotes,
             changeDateTime: this.changeDateTime,
-            changeActiveCalendar: this.changeActiveCalendar
+            changeActiveCalendar: this.changeActiveCalendar,
+            viewExactTime: this.viewExactTime
         };
     }
 
@@ -85,7 +92,8 @@ export default class UserPermissions extends ConfigurationItemBase {
             changeDateTime: this.changeDateTime,
             reorderNotes: this.reorderNotes,
             viewCalendar: this.viewCalendar,
-            changeActiveCalendar: this.changeActiveCalendar
+            changeActiveCalendar: this.changeActiveCalendar,
+            viewExactTime: this.viewExactTime
         };
     }
 
@@ -94,25 +102,16 @@ export default class UserPermissions extends ConfigurationItemBase {
      * @param {UserPermissionsData} config The configuration object for this class
      */
     loadFromSettings(config: SimpleCalendar.UserPermissionsData) {
+        const configurableProperties = ["viewCalendar", "addNotes", "changeDateTime", "reorderNotes", "changeActiveCalendar", "viewExactTime"];
+
+        type ConfigurableProperty = keyof SimpleCalendar.UserPermissionsData & keyof UserPermissions & keyof typeof configurableProperties;
+
         if (config && Object.keys(config).length) {
-            if (Object.prototype.hasOwnProperty.call(config, "viewCalendar") && this.validateUserPermissionMatrix(config.viewCalendar)) {
-                this.viewCalendar = config.viewCalendar;
-            }
-            if (Object.prototype.hasOwnProperty.call(config, "addNotes") && this.validateUserPermissionMatrix(config.addNotes)) {
-                this.addNotes = config.addNotes;
-            }
-            if (Object.prototype.hasOwnProperty.call(config, "changeDateTime") && this.validateUserPermissionMatrix(config.changeDateTime)) {
-                this.changeDateTime = config.changeDateTime;
-            }
-            if (Object.prototype.hasOwnProperty.call(config, "reorderNotes") && this.validateUserPermissionMatrix(config.reorderNotes)) {
-                this.reorderNotes = config.reorderNotes;
-            }
-            if (
-                Object.prototype.hasOwnProperty.call(config, "changeActiveCalendar") &&
-                this.validateUserPermissionMatrix(config.changeActiveCalendar)
-            ) {
-                this.changeActiveCalendar = config.changeActiveCalendar;
-            }
+            (configurableProperties as ConfigurableProperty[]).forEach((key: ConfigurableProperty) => {
+                if (Object.prototype.hasOwnProperty.call(config, key) && this.validateUserPermissionMatrix(config[key])) {
+                    this[key] = config[key];
+                }
+            });
         }
     }
 

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -48,6 +48,8 @@
 	"FSC.Configuration.General.Description": "These settings allow you to configure more general options for the selected calendar.",
 	"FSC.Configuration.General.PlayersChangeActiveCalendar": "Change Active Calendar",
 	"FSC.Configuration.General.PlayersChangeActiveCalendarHelp": "The checked roles will be able to change which calendar is currently active.",
+	"FSC.Configuration.General.PlayersViewExactTime": "Show Exact Time",
+	"FSC.Configuration.General.PlayersViewExactTimeHelp": "The checked roles will be able to see the exact time of day in the calendar.",
 	"FSC.Configuration.Global.Title": "Global Configuration",
 	"FSC.Configuration.Global.Description": "These settings will affect how Simple Calendar works for every calendar as opposed to how a specific calendar will work.",
 	"FSC.Configuration.Global.SameTimestamp.Title": "Calendars Use Same Timestamp",

--- a/src/templates/configuration.hbs
+++ b/src/templates/configuration.hbs
@@ -239,6 +239,16 @@
                     </div>
                     <p class="notes">{{localize 'FSC.Configuration.General.PlayersChangeActiveCalendarHelp'}}</p>
                 </li>
+                <li class="fsc-permission form-group fsc-open">
+                    <label class="fsc-index">{{localize 'FSC.Configuration.General.PlayersViewExactTime'}}</label>
+                    <div class="form-fields">
+                        <input type="checkbox" name="AddNotes.P" id="scViewExactTimeP" data-tooltip="{{localize 'FSC.Configuration.General.PlayersViewExactTime'}}: {{localize 'USER.RolePlayer'}}" aria-label="{{localize 'FSC.Configuration.General.PlayersViewExactTime'}}: {{localize 'USER.RolePlayer'}}" {{checked globalConfiguration.permissions.viewExactTime.player}} />
+                        <input type="checkbox" name="AddNotes.TP" id="scViewExactTimeTP" data-tooltip="{{localize 'FSC.Configuration.General.PlayersViewExactTime'}}: {{localize 'USER.RoleTrusted'}}" aria-label="{{localize 'FSC.Configuration.General.PlayersViewExactTime'}}: {{localize 'USER.RoleTrusted'}}" {{checked globalConfiguration.permissions.viewExactTime.trustedPlayer}} />
+                        <input type="checkbox" name="AddNotes.AGM" id="scViewExactTimeAGM" data-tooltip="{{localize 'FSC.Configuration.General.PlayersViewExactTime'}}: {{localize 'USER.RoleAssistant'}}" aria-label="{{localize 'FSC.Configuration.General.PlayersViewExactTime'}}: {{localize 'USER.RoleAssistant'}}" {{checked globalConfiguration.permissions.viewExactTime.assistantGameMaster}} />
+                        <input type="checkbox" name="AddNotes.GM" data-tooltip="{{localize 'FSC.Configuration.General.PlayersViewExactTime'}}: {{localize 'USER.RoleGamemaster'}}" aria-label="{{localize 'FSC.Configuration.General.PlayersViewExactTime'}}: {{localize 'USER.RoleGamemaster'}}" checked disabled />
+                    </div>
+                    <p class="notes">{{localize 'FSC.Configuration.General.PlayersViewExactTimeHelp'}}</p>
+                </li>
             </ul>
         </div>
         <div class="tab fsc-import-export" data-tab="importExport">

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1500,6 +1500,8 @@ declare global {
                 changeDateTime: PermissionMatrix;
                 /** Who can change the active calendar */
                 changeActiveCalendar: PermissionMatrix;
+                /** Which users can see the detailed time */
+                viewExactTime: PermissionMatrix;
             }
 
             /**
@@ -2255,6 +2257,8 @@ declare global {
             changeDateTime: PermissionMatrix;
             /** Who can change the active calendar */
             changeActiveCalendar: PermissionMatrix;
+            /** Which users can see the detailed time */
+            viewExactTime: PermissionMatrix;
         }
 
         /**


### PR DESCRIPTION
This pull request adds a new permission that allows role-based access to the exact time in the calendar. This closes #597.

Note that currently users may experience issues with the calendar configuration due to the following SCSS snippet expanding each checkbox to the width of the configuration screen: https://github.com/vigoren/foundryvtt-simple-calendar/blob/main/src/styles/scaffolding/form-groups.scss#L70. This PR does not address it directly.